### PR TITLE
Align Left and Right fix for Header

### DIFF
--- a/themes/hydrogen/common/scss/hydrogen/_nav.scss
+++ b/themes/hydrogen/common/scss/hydrogen/_nav.scss
@@ -27,20 +27,6 @@
 		}
 	}
 
-	.align-left {
-		.g-toplevel {
-			justify-content: flex-start;
-			-webkit-justify-content: flex-start;
-		}
-	}
-
-	.align-right {
-		.g-toplevel {
-			justify-content: flex-end;
-			-webkit-justify-content: flex-end;
-		}
-	}
-
 	@include main-nav-indicators($navigation-background, $navigation-text-color);
 
 	.search {
@@ -85,6 +71,22 @@
 			> .g-menu-item-container {
 				padding: ($content-padding + $content-margin)/2 1rem;
 			}
+		}
+	}
+}
+
+#g-navigation, #g-header {
+	.align-left {
+		.g-toplevel {
+			justify-content: flex-start;
+			-webkit-justify-content: flex-start;
+		}
+	}
+
+	.align-right {
+		.g-toplevel {
+			justify-content: flex-end;
+			-webkit-justify-content: flex-end;
 		}
 	}
 }


### PR DESCRIPTION
Fix for "Align Left" and "Align Right" Variations for the Menu in the Header Section.
These variations currently work only if the Menu is in the Navigation Section.