### PR TITLE
Boxed Width Option

### DIFF
--- a/themes/hydrogen/common/blueprints/styles/base.yaml
+++ b/themes/hydrogen/common/blueprints/styles/base.yaml
@@ -21,3 +21,9 @@ form:
       type: input.fonts
       label: Heading Font
       default: 'roboto, sans-serif'
+    width:
+      type: input.text
+      label: Boxed Width
+      description: Set width size in rem or % values
+      default: "75rem"
+      pattern: '\d+(\.\d+){0,1}(rem|%)'

--- a/themes/hydrogen/common/scss/hydrogen/_core.scss
+++ b/themes/hydrogen/common/scss/hydrogen/_core.scss
@@ -7,6 +7,52 @@ body {
 
 #g-page-surround {
 	background: $base-background;
+	
+	/* Smartphones */
+	@media (max-width: 480px) {
+		@if $base-width {
+		margin: 0 auto;
+		} @else {
+		margin: 0 0 0 1.54rem;
+		width: 100%;
+	}}
+	
+	/* Smartphones to Tablets */
+	@media (min-width: 481px) and (max-width: 767px) {
+		@if $base-width {
+		margin: 0 auto;
+		} @else {
+		margin: 0 0 0 1.54rem;
+		width: 100%;
+	}}
+	
+	/* Tablets */
+	@media (min-width: 768px) and (max-width: 959px) {
+		@if $base-width {
+		margin: 0 auto;
+		} @else {
+		margin: 0 0 0 1.54rem;
+		width: 100%;
+	}}
+	
+	/* Desktop */
+	@media (min-width: 960px) and (max-width: 1199px) { 
+		@if $base-width {
+		margin: 0 auto;
+		} @else {
+		margin: 0 0 0 1.54rem;
+		width: 100%;
+	}}
+	
+	/* Large Display */
+	@media (min-width: 1200px) {
+		@if $base-width {
+		width: $base-width;
+		margin: 0 auto;
+		} @else {
+		margin: 0 0 0 1.54rem;
+		width: 100%;
+	}}
 }
 
 @media print {


### PR DESCRIPTION
Allows the user to enable boxed design and specify in rem or % the width of their site. It leaves the breakpoints setting to control the proximity to the boxed design wall. The user can then control both to a width they prefer.

Not 100% on the mediaqueries.

This is an alternative proposal to #301 