### PR TITLE
Default dropdown animation value should not be forced

### DIFF
--- a/engines/common/nucleus/particles/menu.html.twig
+++ b/engines/common/nucleus/particles/menu.html.twig
@@ -97,7 +97,7 @@
     {% if hasCustomWidth and not (root.getDropdown() == 'fullwidth' and item.level > 1) %}
         {% set customWidth = ' style="width: ' ~ item.width|raw ~ '" data-g-item-width="' ~ item.width|raw ~ '"' %}
     {% endif %}
-    <ul class="g-dropdown g-inactive {{ gantry.config.get('styles.menu.animation')|default('g-fade') }}"{{ customWidth|raw }}>
+    <ul class="g-dropdown g-inactive {{ gantry.config.get('styles.menu.animation') }}"{{ customWidth|raw }}>
         <li class="g-dropdown-column">
             {{ _self.displayContainers(item, root, menu, gantry) }}
         </li>


### PR DESCRIPTION
Default dropdown animation value should not be forced, so anyone can set a default value in `yaml` file.