### PR TITLE
Italy Cookie Law

### DIFF
--- a/engines/common/nucleus/particles/analytics.yaml
+++ b/engines/common/nucleus/particles/analytics.yaml
@@ -17,7 +17,7 @@ form:
 
     ua.anonym:
       type: input.checkbox
-      description: Send only Anonymous IP Addresses (mandatory in Germany and Italy)
+      description: Send only Anonymous IP Addresses (mandatory in Europe)
       label: Anonym Statistics
       default: false
 

--- a/engines/common/nucleus/particles/analytics.yaml
+++ b/engines/common/nucleus/particles/analytics.yaml
@@ -17,7 +17,7 @@ form:
 
     ua.anonym:
       type: input.checkbox
-      description: Send only Anonymous IP Addresses (mandatory in Germany)
+      description: Send only Anonymous IP Addresses (mandatory in Germany and Italy)
       label: Anonym Statistics
       default: false
 


### PR DESCRIPTION
With the new Cookie Law in Italy, anonymize google analytics is mandatory.