### PR TITLE
Update bootstrap-gantry.css

### DIFF
--- a/assets/joomla/css/bootstrap-gantry.css
+++ b/assets/joomla/css/bootstrap-gantry.css
@@ -5176,8 +5176,10 @@ a.badge:focus {
 	visibility: hidden;
 }
 
-.affix {
+.affix, header.affix, section.affix, footer.affix {
 	position: fixed;
+	left: 0;
+	right: 0;
 }
 
 /* Joomla JUI NOTE: Original .modal definition has to be commented in modals.less and responsive-767px-max.less */


### PR DESCRIPTION
affix `position: fixed` will be ignored, if section have other position defined. I am not sure this is the right fix, but... I've added left, right values because this is how most of the users use it.