### PR TITLE
Update meta-date.yaml

### DIFF
--- a/themes/hydrogen/wordpress/blueprints/content/page/meta-date.yaml
+++ b/themes/hydrogen/wordpress/blueprints/content/page/meta-date.yaml
@@ -38,6 +38,7 @@ form:
           'l': Date10
           'l j F Y': Date11
           'j F Y': Date12
+          'F d, Y': Date13
 
     prefix:
       type: input.text


### PR DESCRIPTION
Added date option for October 22, 2015. Would like to see this change propagated to all themes. This is the common date setting for the USA.