### PR TITLE
Fix half missing closing icon on alert

### DIFF
--- a/engines/joomla/nucleus/css-compiled/joomla.css
+++ b/engines/joomla/nucleus/css-compiled/joomla.css
@@ -516,7 +516,7 @@ th .tooltip-inner {
 
 .alert {
   border-radius: 0.1875rem;
-  padding: 0.938rem;
+  padding: 0.938rem 2rem 0.938rem 0.938rem;
   margin-bottom: 1.5rem;
   text-shadow: none;
 }


### PR DESCRIPTION
The icon is now half hidden on the alert info messagebox
![2015-11-23 1](https://cloud.githubusercontent.com/assets/876623/11333577/fb65d130-91ce-11e5-8a44-c9b02e50088b.png)
