### PR TITLE
Make decimal point sizes flex compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     2. [](#improved)
         - Selectize is now name-spaced with a `g-` prefix to avoid potential conflicts
         - Layout Manager: Add Row and Section Settings action icons are now always visible
+        - Decimal size classes (`size-33-3`) are also using flexgrid (#1047 - thanks @adi8i)
 2. [Joomla](#joomla)
     3. [](#bugfix)
         - Fixed dismissal links alignment for alerts (fixes #1022)

--- a/engines/common/nucleus/css-compiled/nucleus.css
+++ b/engines/common/nucleus/css-compiled/nucleus.css
@@ -1,7 +1,3 @@
-.size-100 {
-  width: 100%;
-}
-
 .g-main-nav .g-dropdown, .g-main-nav .g-standard .g-dropdown .g-dropdown {
   position: absolute;
   top: auto;
@@ -329,759 +325,1085 @@ th {
 }
 
 .size-5 {
-  -webkit-flex: 0 1 5%;
-  -moz-flex: 0 1 5%;
-  -ms-flex: 0 1 5%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 5%;
+  -moz-flex: 0 5%;
+  -ms-flex: 0 5%;
   flex: 0 5%;
   width: 5%;
 }
 
 .size-6 {
-  -webkit-flex: 0 1 6%;
-  -moz-flex: 0 1 6%;
-  -ms-flex: 0 1 6%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 6%;
+  -moz-flex: 0 6%;
+  -ms-flex: 0 6%;
   flex: 0 6%;
   width: 6%;
 }
 
 .size-7 {
-  -webkit-flex: 0 1 7%;
-  -moz-flex: 0 1 7%;
-  -ms-flex: 0 1 7%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 7%;
+  -moz-flex: 0 7%;
+  -ms-flex: 0 7%;
   flex: 0 7%;
   width: 7%;
 }
 
 .size-8 {
-  -webkit-flex: 0 1 8%;
-  -moz-flex: 0 1 8%;
-  -ms-flex: 0 1 8%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 8%;
+  -moz-flex: 0 8%;
+  -ms-flex: 0 8%;
   flex: 0 8%;
   width: 8%;
 }
 
 .size-9 {
-  -webkit-flex: 0 1 9%;
-  -moz-flex: 0 1 9%;
-  -ms-flex: 0 1 9%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 9%;
+  -moz-flex: 0 9%;
+  -ms-flex: 0 9%;
   flex: 0 9%;
   width: 9%;
 }
 
 .size-10 {
-  -webkit-flex: 0 1 10%;
-  -moz-flex: 0 1 10%;
-  -ms-flex: 0 1 10%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 10%;
+  -moz-flex: 0 10%;
+  -ms-flex: 0 10%;
   flex: 0 10%;
   width: 10%;
 }
 
 .size-11 {
-  -webkit-flex: 0 1 11%;
-  -moz-flex: 0 1 11%;
-  -ms-flex: 0 1 11%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 11%;
+  -moz-flex: 0 11%;
+  -ms-flex: 0 11%;
   flex: 0 11%;
   width: 11%;
 }
 
 .size-12 {
-  -webkit-flex: 0 1 12%;
-  -moz-flex: 0 1 12%;
-  -ms-flex: 0 1 12%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 12%;
+  -moz-flex: 0 12%;
+  -ms-flex: 0 12%;
   flex: 0 12%;
   width: 12%;
 }
 
 .size-13 {
-  -webkit-flex: 0 1 13%;
-  -moz-flex: 0 1 13%;
-  -ms-flex: 0 1 13%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 13%;
+  -moz-flex: 0 13%;
+  -ms-flex: 0 13%;
   flex: 0 13%;
   width: 13%;
 }
 
 .size-14 {
-  -webkit-flex: 0 1 14%;
-  -moz-flex: 0 1 14%;
-  -ms-flex: 0 1 14%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 14%;
+  -moz-flex: 0 14%;
+  -ms-flex: 0 14%;
   flex: 0 14%;
   width: 14%;
 }
 
 .size-15 {
-  -webkit-flex: 0 1 15%;
-  -moz-flex: 0 1 15%;
-  -ms-flex: 0 1 15%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 15%;
+  -moz-flex: 0 15%;
+  -ms-flex: 0 15%;
   flex: 0 15%;
   width: 15%;
 }
 
 .size-16 {
-  -webkit-flex: 0 1 16%;
-  -moz-flex: 0 1 16%;
-  -ms-flex: 0 1 16%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 16%;
+  -moz-flex: 0 16%;
+  -ms-flex: 0 16%;
   flex: 0 16%;
   width: 16%;
 }
 
 .size-17 {
-  -webkit-flex: 0 1 17%;
-  -moz-flex: 0 1 17%;
-  -ms-flex: 0 1 17%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 17%;
+  -moz-flex: 0 17%;
+  -ms-flex: 0 17%;
   flex: 0 17%;
   width: 17%;
 }
 
 .size-18 {
-  -webkit-flex: 0 1 18%;
-  -moz-flex: 0 1 18%;
-  -ms-flex: 0 1 18%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 18%;
+  -moz-flex: 0 18%;
+  -ms-flex: 0 18%;
   flex: 0 18%;
   width: 18%;
 }
 
 .size-19 {
-  -webkit-flex: 0 1 19%;
-  -moz-flex: 0 1 19%;
-  -ms-flex: 0 1 19%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 19%;
+  -moz-flex: 0 19%;
+  -ms-flex: 0 19%;
   flex: 0 19%;
   width: 19%;
 }
 
 .size-20 {
-  -webkit-flex: 0 1 20%;
-  -moz-flex: 0 1 20%;
-  -ms-flex: 0 1 20%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 20%;
+  -moz-flex: 0 20%;
+  -ms-flex: 0 20%;
   flex: 0 20%;
   width: 20%;
 }
 
 .size-21 {
-  -webkit-flex: 0 1 21%;
-  -moz-flex: 0 1 21%;
-  -ms-flex: 0 1 21%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 21%;
+  -moz-flex: 0 21%;
+  -ms-flex: 0 21%;
   flex: 0 21%;
   width: 21%;
 }
 
 .size-22 {
-  -webkit-flex: 0 1 22%;
-  -moz-flex: 0 1 22%;
-  -ms-flex: 0 1 22%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 22%;
+  -moz-flex: 0 22%;
+  -ms-flex: 0 22%;
   flex: 0 22%;
   width: 22%;
 }
 
 .size-23 {
-  -webkit-flex: 0 1 23%;
-  -moz-flex: 0 1 23%;
-  -ms-flex: 0 1 23%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 23%;
+  -moz-flex: 0 23%;
+  -ms-flex: 0 23%;
   flex: 0 23%;
   width: 23%;
 }
 
 .size-24 {
-  -webkit-flex: 0 1 24%;
-  -moz-flex: 0 1 24%;
-  -ms-flex: 0 1 24%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 24%;
+  -moz-flex: 0 24%;
+  -ms-flex: 0 24%;
   flex: 0 24%;
   width: 24%;
 }
 
 .size-25 {
-  -webkit-flex: 0 1 25%;
-  -moz-flex: 0 1 25%;
-  -ms-flex: 0 1 25%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 25%;
+  -moz-flex: 0 25%;
+  -ms-flex: 0 25%;
   flex: 0 25%;
   width: 25%;
 }
 
 .size-26 {
-  -webkit-flex: 0 1 26%;
-  -moz-flex: 0 1 26%;
-  -ms-flex: 0 1 26%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 26%;
+  -moz-flex: 0 26%;
+  -ms-flex: 0 26%;
   flex: 0 26%;
   width: 26%;
 }
 
 .size-27 {
-  -webkit-flex: 0 1 27%;
-  -moz-flex: 0 1 27%;
-  -ms-flex: 0 1 27%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 27%;
+  -moz-flex: 0 27%;
+  -ms-flex: 0 27%;
   flex: 0 27%;
   width: 27%;
 }
 
 .size-28 {
-  -webkit-flex: 0 1 28%;
-  -moz-flex: 0 1 28%;
-  -ms-flex: 0 1 28%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 28%;
+  -moz-flex: 0 28%;
+  -ms-flex: 0 28%;
   flex: 0 28%;
   width: 28%;
 }
 
 .size-29 {
-  -webkit-flex: 0 1 29%;
-  -moz-flex: 0 1 29%;
-  -ms-flex: 0 1 29%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 29%;
+  -moz-flex: 0 29%;
+  -ms-flex: 0 29%;
   flex: 0 29%;
   width: 29%;
 }
 
 .size-30 {
-  -webkit-flex: 0 1 30%;
-  -moz-flex: 0 1 30%;
-  -ms-flex: 0 1 30%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 30%;
+  -moz-flex: 0 30%;
+  -ms-flex: 0 30%;
   flex: 0 30%;
   width: 30%;
 }
 
 .size-31 {
-  -webkit-flex: 0 1 31%;
-  -moz-flex: 0 1 31%;
-  -ms-flex: 0 1 31%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 31%;
+  -moz-flex: 0 31%;
+  -ms-flex: 0 31%;
   flex: 0 31%;
   width: 31%;
 }
 
 .size-32 {
-  -webkit-flex: 0 1 32%;
-  -moz-flex: 0 1 32%;
-  -ms-flex: 0 1 32%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 32%;
+  -moz-flex: 0 32%;
+  -ms-flex: 0 32%;
   flex: 0 32%;
   width: 32%;
 }
 
 .size-33 {
-  -webkit-flex: 0 1 33%;
-  -moz-flex: 0 1 33%;
-  -ms-flex: 0 1 33%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 33%;
+  -moz-flex: 0 33%;
+  -ms-flex: 0 33%;
   flex: 0 33%;
   width: 33%;
 }
 
 .size-34 {
-  -webkit-flex: 0 1 34%;
-  -moz-flex: 0 1 34%;
-  -ms-flex: 0 1 34%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 34%;
+  -moz-flex: 0 34%;
+  -ms-flex: 0 34%;
   flex: 0 34%;
   width: 34%;
 }
 
 .size-35 {
-  -webkit-flex: 0 1 35%;
-  -moz-flex: 0 1 35%;
-  -ms-flex: 0 1 35%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 35%;
+  -moz-flex: 0 35%;
+  -ms-flex: 0 35%;
   flex: 0 35%;
   width: 35%;
 }
 
 .size-36 {
-  -webkit-flex: 0 1 36%;
-  -moz-flex: 0 1 36%;
-  -ms-flex: 0 1 36%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 36%;
+  -moz-flex: 0 36%;
+  -ms-flex: 0 36%;
   flex: 0 36%;
   width: 36%;
 }
 
 .size-37 {
-  -webkit-flex: 0 1 37%;
-  -moz-flex: 0 1 37%;
-  -ms-flex: 0 1 37%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 37%;
+  -moz-flex: 0 37%;
+  -ms-flex: 0 37%;
   flex: 0 37%;
   width: 37%;
 }
 
 .size-38 {
-  -webkit-flex: 0 1 38%;
-  -moz-flex: 0 1 38%;
-  -ms-flex: 0 1 38%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 38%;
+  -moz-flex: 0 38%;
+  -ms-flex: 0 38%;
   flex: 0 38%;
   width: 38%;
 }
 
 .size-39 {
-  -webkit-flex: 0 1 39%;
-  -moz-flex: 0 1 39%;
-  -ms-flex: 0 1 39%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 39%;
+  -moz-flex: 0 39%;
+  -ms-flex: 0 39%;
   flex: 0 39%;
   width: 39%;
 }
 
 .size-40 {
-  -webkit-flex: 0 1 40%;
-  -moz-flex: 0 1 40%;
-  -ms-flex: 0 1 40%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 40%;
+  -moz-flex: 0 40%;
+  -ms-flex: 0 40%;
   flex: 0 40%;
   width: 40%;
 }
 
 .size-41 {
-  -webkit-flex: 0 1 41%;
-  -moz-flex: 0 1 41%;
-  -ms-flex: 0 1 41%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 41%;
+  -moz-flex: 0 41%;
+  -ms-flex: 0 41%;
   flex: 0 41%;
   width: 41%;
 }
 
 .size-42 {
-  -webkit-flex: 0 1 42%;
-  -moz-flex: 0 1 42%;
-  -ms-flex: 0 1 42%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 42%;
+  -moz-flex: 0 42%;
+  -ms-flex: 0 42%;
   flex: 0 42%;
   width: 42%;
 }
 
 .size-43 {
-  -webkit-flex: 0 1 43%;
-  -moz-flex: 0 1 43%;
-  -ms-flex: 0 1 43%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 43%;
+  -moz-flex: 0 43%;
+  -ms-flex: 0 43%;
   flex: 0 43%;
   width: 43%;
 }
 
 .size-44 {
-  -webkit-flex: 0 1 44%;
-  -moz-flex: 0 1 44%;
-  -ms-flex: 0 1 44%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 44%;
+  -moz-flex: 0 44%;
+  -ms-flex: 0 44%;
   flex: 0 44%;
   width: 44%;
 }
 
 .size-45 {
-  -webkit-flex: 0 1 45%;
-  -moz-flex: 0 1 45%;
-  -ms-flex: 0 1 45%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 45%;
+  -moz-flex: 0 45%;
+  -ms-flex: 0 45%;
   flex: 0 45%;
   width: 45%;
 }
 
 .size-46 {
-  -webkit-flex: 0 1 46%;
-  -moz-flex: 0 1 46%;
-  -ms-flex: 0 1 46%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 46%;
+  -moz-flex: 0 46%;
+  -ms-flex: 0 46%;
   flex: 0 46%;
   width: 46%;
 }
 
 .size-47 {
-  -webkit-flex: 0 1 47%;
-  -moz-flex: 0 1 47%;
-  -ms-flex: 0 1 47%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 47%;
+  -moz-flex: 0 47%;
+  -ms-flex: 0 47%;
   flex: 0 47%;
   width: 47%;
 }
 
 .size-48 {
-  -webkit-flex: 0 1 48%;
-  -moz-flex: 0 1 48%;
-  -ms-flex: 0 1 48%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 48%;
+  -moz-flex: 0 48%;
+  -ms-flex: 0 48%;
   flex: 0 48%;
   width: 48%;
 }
 
 .size-49 {
-  -webkit-flex: 0 1 49%;
-  -moz-flex: 0 1 49%;
-  -ms-flex: 0 1 49%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 49%;
+  -moz-flex: 0 49%;
+  -ms-flex: 0 49%;
   flex: 0 49%;
   width: 49%;
 }
 
 .size-50 {
-  -webkit-flex: 0 1 50%;
-  -moz-flex: 0 1 50%;
-  -ms-flex: 0 1 50%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 50%;
+  -moz-flex: 0 50%;
+  -ms-flex: 0 50%;
   flex: 0 50%;
   width: 50%;
 }
 
 .size-51 {
-  -webkit-flex: 0 1 51%;
-  -moz-flex: 0 1 51%;
-  -ms-flex: 0 1 51%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 51%;
+  -moz-flex: 0 51%;
+  -ms-flex: 0 51%;
   flex: 0 51%;
   width: 51%;
 }
 
 .size-52 {
-  -webkit-flex: 0 1 52%;
-  -moz-flex: 0 1 52%;
-  -ms-flex: 0 1 52%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 52%;
+  -moz-flex: 0 52%;
+  -ms-flex: 0 52%;
   flex: 0 52%;
   width: 52%;
 }
 
 .size-53 {
-  -webkit-flex: 0 1 53%;
-  -moz-flex: 0 1 53%;
-  -ms-flex: 0 1 53%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 53%;
+  -moz-flex: 0 53%;
+  -ms-flex: 0 53%;
   flex: 0 53%;
   width: 53%;
 }
 
 .size-54 {
-  -webkit-flex: 0 1 54%;
-  -moz-flex: 0 1 54%;
-  -ms-flex: 0 1 54%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 54%;
+  -moz-flex: 0 54%;
+  -ms-flex: 0 54%;
   flex: 0 54%;
   width: 54%;
 }
 
 .size-55 {
-  -webkit-flex: 0 1 55%;
-  -moz-flex: 0 1 55%;
-  -ms-flex: 0 1 55%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 55%;
+  -moz-flex: 0 55%;
+  -ms-flex: 0 55%;
   flex: 0 55%;
   width: 55%;
 }
 
 .size-56 {
-  -webkit-flex: 0 1 56%;
-  -moz-flex: 0 1 56%;
-  -ms-flex: 0 1 56%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 56%;
+  -moz-flex: 0 56%;
+  -ms-flex: 0 56%;
   flex: 0 56%;
   width: 56%;
 }
 
 .size-57 {
-  -webkit-flex: 0 1 57%;
-  -moz-flex: 0 1 57%;
-  -ms-flex: 0 1 57%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 57%;
+  -moz-flex: 0 57%;
+  -ms-flex: 0 57%;
   flex: 0 57%;
   width: 57%;
 }
 
 .size-58 {
-  -webkit-flex: 0 1 58%;
-  -moz-flex: 0 1 58%;
-  -ms-flex: 0 1 58%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 58%;
+  -moz-flex: 0 58%;
+  -ms-flex: 0 58%;
   flex: 0 58%;
   width: 58%;
 }
 
 .size-59 {
-  -webkit-flex: 0 1 59%;
-  -moz-flex: 0 1 59%;
-  -ms-flex: 0 1 59%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 59%;
+  -moz-flex: 0 59%;
+  -ms-flex: 0 59%;
   flex: 0 59%;
   width: 59%;
 }
 
 .size-60 {
-  -webkit-flex: 0 1 60%;
-  -moz-flex: 0 1 60%;
-  -ms-flex: 0 1 60%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 60%;
+  -moz-flex: 0 60%;
+  -ms-flex: 0 60%;
   flex: 0 60%;
   width: 60%;
 }
 
 .size-61 {
-  -webkit-flex: 0 1 61%;
-  -moz-flex: 0 1 61%;
-  -ms-flex: 0 1 61%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 61%;
+  -moz-flex: 0 61%;
+  -ms-flex: 0 61%;
   flex: 0 61%;
   width: 61%;
 }
 
 .size-62 {
-  -webkit-flex: 0 1 62%;
-  -moz-flex: 0 1 62%;
-  -ms-flex: 0 1 62%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 62%;
+  -moz-flex: 0 62%;
+  -ms-flex: 0 62%;
   flex: 0 62%;
   width: 62%;
 }
 
 .size-63 {
-  -webkit-flex: 0 1 63%;
-  -moz-flex: 0 1 63%;
-  -ms-flex: 0 1 63%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 63%;
+  -moz-flex: 0 63%;
+  -ms-flex: 0 63%;
   flex: 0 63%;
   width: 63%;
 }
 
 .size-64 {
-  -webkit-flex: 0 1 64%;
-  -moz-flex: 0 1 64%;
-  -ms-flex: 0 1 64%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 64%;
+  -moz-flex: 0 64%;
+  -ms-flex: 0 64%;
   flex: 0 64%;
   width: 64%;
 }
 
 .size-65 {
-  -webkit-flex: 0 1 65%;
-  -moz-flex: 0 1 65%;
-  -ms-flex: 0 1 65%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 65%;
+  -moz-flex: 0 65%;
+  -ms-flex: 0 65%;
   flex: 0 65%;
   width: 65%;
 }
 
 .size-66 {
-  -webkit-flex: 0 1 66%;
-  -moz-flex: 0 1 66%;
-  -ms-flex: 0 1 66%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 66%;
+  -moz-flex: 0 66%;
+  -ms-flex: 0 66%;
   flex: 0 66%;
   width: 66%;
 }
 
 .size-67 {
-  -webkit-flex: 0 1 67%;
-  -moz-flex: 0 1 67%;
-  -ms-flex: 0 1 67%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 67%;
+  -moz-flex: 0 67%;
+  -ms-flex: 0 67%;
   flex: 0 67%;
   width: 67%;
 }
 
 .size-68 {
-  -webkit-flex: 0 1 68%;
-  -moz-flex: 0 1 68%;
-  -ms-flex: 0 1 68%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 68%;
+  -moz-flex: 0 68%;
+  -ms-flex: 0 68%;
   flex: 0 68%;
   width: 68%;
 }
 
 .size-69 {
-  -webkit-flex: 0 1 69%;
-  -moz-flex: 0 1 69%;
-  -ms-flex: 0 1 69%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 69%;
+  -moz-flex: 0 69%;
+  -ms-flex: 0 69%;
   flex: 0 69%;
   width: 69%;
 }
 
 .size-70 {
-  -webkit-flex: 0 1 70%;
-  -moz-flex: 0 1 70%;
-  -ms-flex: 0 1 70%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 70%;
+  -moz-flex: 0 70%;
+  -ms-flex: 0 70%;
   flex: 0 70%;
   width: 70%;
 }
 
 .size-71 {
-  -webkit-flex: 0 1 71%;
-  -moz-flex: 0 1 71%;
-  -ms-flex: 0 1 71%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 71%;
+  -moz-flex: 0 71%;
+  -ms-flex: 0 71%;
   flex: 0 71%;
   width: 71%;
 }
 
 .size-72 {
-  -webkit-flex: 0 1 72%;
-  -moz-flex: 0 1 72%;
-  -ms-flex: 0 1 72%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 72%;
+  -moz-flex: 0 72%;
+  -ms-flex: 0 72%;
   flex: 0 72%;
   width: 72%;
 }
 
 .size-73 {
-  -webkit-flex: 0 1 73%;
-  -moz-flex: 0 1 73%;
-  -ms-flex: 0 1 73%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 73%;
+  -moz-flex: 0 73%;
+  -ms-flex: 0 73%;
   flex: 0 73%;
   width: 73%;
 }
 
 .size-74 {
-  -webkit-flex: 0 1 74%;
-  -moz-flex: 0 1 74%;
-  -ms-flex: 0 1 74%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 74%;
+  -moz-flex: 0 74%;
+  -ms-flex: 0 74%;
   flex: 0 74%;
   width: 74%;
 }
 
 .size-75 {
-  -webkit-flex: 0 1 75%;
-  -moz-flex: 0 1 75%;
-  -ms-flex: 0 1 75%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 75%;
+  -moz-flex: 0 75%;
+  -ms-flex: 0 75%;
   flex: 0 75%;
   width: 75%;
 }
 
 .size-76 {
-  -webkit-flex: 0 1 76%;
-  -moz-flex: 0 1 76%;
-  -ms-flex: 0 1 76%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 76%;
+  -moz-flex: 0 76%;
+  -ms-flex: 0 76%;
   flex: 0 76%;
   width: 76%;
 }
 
 .size-77 {
-  -webkit-flex: 0 1 77%;
-  -moz-flex: 0 1 77%;
-  -ms-flex: 0 1 77%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 77%;
+  -moz-flex: 0 77%;
+  -ms-flex: 0 77%;
   flex: 0 77%;
   width: 77%;
 }
 
 .size-78 {
-  -webkit-flex: 0 1 78%;
-  -moz-flex: 0 1 78%;
-  -ms-flex: 0 1 78%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 78%;
+  -moz-flex: 0 78%;
+  -ms-flex: 0 78%;
   flex: 0 78%;
   width: 78%;
 }
 
 .size-79 {
-  -webkit-flex: 0 1 79%;
-  -moz-flex: 0 1 79%;
-  -ms-flex: 0 1 79%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 79%;
+  -moz-flex: 0 79%;
+  -ms-flex: 0 79%;
   flex: 0 79%;
   width: 79%;
 }
 
 .size-80 {
-  -webkit-flex: 0 1 80%;
-  -moz-flex: 0 1 80%;
-  -ms-flex: 0 1 80%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 80%;
+  -moz-flex: 0 80%;
+  -ms-flex: 0 80%;
   flex: 0 80%;
   width: 80%;
 }
 
 .size-81 {
-  -webkit-flex: 0 1 81%;
-  -moz-flex: 0 1 81%;
-  -ms-flex: 0 1 81%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 81%;
+  -moz-flex: 0 81%;
+  -ms-flex: 0 81%;
   flex: 0 81%;
   width: 81%;
 }
 
 .size-82 {
-  -webkit-flex: 0 1 82%;
-  -moz-flex: 0 1 82%;
-  -ms-flex: 0 1 82%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 82%;
+  -moz-flex: 0 82%;
+  -ms-flex: 0 82%;
   flex: 0 82%;
   width: 82%;
 }
 
 .size-83 {
-  -webkit-flex: 0 1 83%;
-  -moz-flex: 0 1 83%;
-  -ms-flex: 0 1 83%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 83%;
+  -moz-flex: 0 83%;
+  -ms-flex: 0 83%;
   flex: 0 83%;
   width: 83%;
 }
 
 .size-84 {
-  -webkit-flex: 0 1 84%;
-  -moz-flex: 0 1 84%;
-  -ms-flex: 0 1 84%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 84%;
+  -moz-flex: 0 84%;
+  -ms-flex: 0 84%;
   flex: 0 84%;
   width: 84%;
 }
 
 .size-85 {
-  -webkit-flex: 0 1 85%;
-  -moz-flex: 0 1 85%;
-  -ms-flex: 0 1 85%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 85%;
+  -moz-flex: 0 85%;
+  -ms-flex: 0 85%;
   flex: 0 85%;
   width: 85%;
 }
 
 .size-86 {
-  -webkit-flex: 0 1 86%;
-  -moz-flex: 0 1 86%;
-  -ms-flex: 0 1 86%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 86%;
+  -moz-flex: 0 86%;
+  -ms-flex: 0 86%;
   flex: 0 86%;
   width: 86%;
 }
 
 .size-87 {
-  -webkit-flex: 0 1 87%;
-  -moz-flex: 0 1 87%;
-  -ms-flex: 0 1 87%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 87%;
+  -moz-flex: 0 87%;
+  -ms-flex: 0 87%;
   flex: 0 87%;
   width: 87%;
 }
 
 .size-88 {
-  -webkit-flex: 0 1 88%;
-  -moz-flex: 0 1 88%;
-  -ms-flex: 0 1 88%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 88%;
+  -moz-flex: 0 88%;
+  -ms-flex: 0 88%;
   flex: 0 88%;
   width: 88%;
 }
 
 .size-89 {
-  -webkit-flex: 0 1 89%;
-  -moz-flex: 0 1 89%;
-  -ms-flex: 0 1 89%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 89%;
+  -moz-flex: 0 89%;
+  -ms-flex: 0 89%;
   flex: 0 89%;
   width: 89%;
 }
 
 .size-90 {
-  -webkit-flex: 0 1 90%;
-  -moz-flex: 0 1 90%;
-  -ms-flex: 0 1 90%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 90%;
+  -moz-flex: 0 90%;
+  -ms-flex: 0 90%;
   flex: 0 90%;
   width: 90%;
 }
 
 .size-91 {
-  -webkit-flex: 0 1 91%;
-  -moz-flex: 0 1 91%;
-  -ms-flex: 0 1 91%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 91%;
+  -moz-flex: 0 91%;
+  -ms-flex: 0 91%;
   flex: 0 91%;
   width: 91%;
 }
 
 .size-92 {
-  -webkit-flex: 0 1 92%;
-  -moz-flex: 0 1 92%;
-  -ms-flex: 0 1 92%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 92%;
+  -moz-flex: 0 92%;
+  -ms-flex: 0 92%;
   flex: 0 92%;
   width: 92%;
 }
 
 .size-93 {
-  -webkit-flex: 0 1 93%;
-  -moz-flex: 0 1 93%;
-  -ms-flex: 0 1 93%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 93%;
+  -moz-flex: 0 93%;
+  -ms-flex: 0 93%;
   flex: 0 93%;
   width: 93%;
 }
 
 .size-94 {
-  -webkit-flex: 0 1 94%;
-  -moz-flex: 0 1 94%;
-  -ms-flex: 0 1 94%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 94%;
+  -moz-flex: 0 94%;
+  -ms-flex: 0 94%;
   flex: 0 94%;
   width: 94%;
 }
 
 .size-95 {
-  -webkit-flex: 0 1 95%;
-  -moz-flex: 0 1 95%;
-  -ms-flex: 0 1 95%;
+  -webkit-box-flex: 0;
+  -moz-box-flex: 0;
+  box-flex: 0;
+  -webkit-flex: 0 95%;
+  -moz-flex: 0 95%;
+  -ms-flex: 0 95%;
   flex: 0 95%;
   width: 95%;
 }
 
 .size-33-3 {
+  -webkit-box-flex: 33.33333%;
+  -moz-box-flex: 33.33333%;
+  box-flex: 33.33333%;
+  -webkit-flex: 33.33333%;
+  -moz-flex: 33.33333%;
+  -ms-flex: 33.33333%;
+  flex: 33.33333%;
   width: 33.33333%;
 }
 
 .size-16-7 {
+  -webkit-box-flex: 16.66667%;
+  -moz-box-flex: 16.66667%;
+  box-flex: 16.66667%;
+  -webkit-flex: 16.66667%;
+  -moz-flex: 16.66667%;
+  -ms-flex: 16.66667%;
+  flex: 16.66667%;
   width: 16.66667%;
 }
 
 .size-14-3 {
+  -webkit-box-flex: 14.28571%;
+  -moz-box-flex: 14.28571%;
+  box-flex: 14.28571%;
+  -webkit-flex: 14.28571%;
+  -moz-flex: 14.28571%;
+  -ms-flex: 14.28571%;
+  flex: 14.28571%;
   width: 14.28571%;
 }
 
 .size-12-5 {
+  -webkit-box-flex: 12.5%;
+  -moz-box-flex: 12.5%;
+  box-flex: 12.5%;
+  -webkit-flex: 12.5%;
+  -moz-flex: 12.5%;
+  -ms-flex: 12.5%;
+  flex: 12.5%;
   width: 12.5%;
 }
 
 .size-11-1 {
+  -webkit-box-flex: 11.11111%;
+  -moz-box-flex: 11.11111%;
+  box-flex: 11.11111%;
+  -webkit-flex: 11.11111%;
+  -moz-flex: 11.11111%;
+  -ms-flex: 11.11111%;
+  flex: 11.11111%;
   width: 11.11111%;
 }
 
 .size-9-1 {
+  -webkit-box-flex: 9.09091%;
+  -moz-box-flex: 9.09091%;
+  box-flex: 9.09091%;
+  -webkit-flex: 9.09091%;
+  -moz-flex: 9.09091%;
+  -ms-flex: 9.09091%;
+  flex: 9.09091%;
   width: 9.09091%;
 }
 
 .size-8-3 {
+  -webkit-box-flex: 8.33333%;
+  -moz-box-flex: 8.33333%;
+  box-flex: 8.33333%;
+  -webkit-flex: 8.33333%;
+  -moz-flex: 8.33333%;
+  -ms-flex: 8.33333%;
+  flex: 8.33333%;
   width: 8.33333%;
+}
+
+.size-100 {
+  width: 100%;
 }
 
 .g-main-nav:not(.g-menu-hastouch) .g-dropdown {

--- a/engines/common/nucleus/scss/nucleus/_sizes.scss
+++ b/engines/common/nucleus/scss/nucleus/_sizes.scss
@@ -2,30 +2,12 @@
 @include size-x;
 
 // Equal size fallbacks for older browsers
-.size-33-3 {
-	width: percentage(1/3);
-}
-
-.size-16-7 {
-	width: percentage(1/6);
-}
-
-.size-14-3 {
-	width: percentage(1/7);
-}
-
-.size-12-5 {
-	width: percentage(1/8);
-}
-
-.size-11-1 {
-	width: percentage(1/9);
-}
-
-.size-9-1 {
-	width: percentage(1/11);
-}
-
-.size-8-3 {
-	width: percentage(1/12);
+@each $i, $n in ('33-3', 1/3), ('16-7', 1/6), ('14-3', 1/7), ('12-5', 1/8), ('11-1', 1/9), ('9-1', 1/11), ('8-3', 1/12) {
+    .size-#{$i} {
+        -webkit-flex: 0 1 percentage($n);
+        -moz-flex: 0 1 percentage($n);
+        -ms-flex: 0 1 percentage($n);
+        flex: 0 percentage($n);
+        width: percentage($n);
+    }
 }

--- a/engines/common/nucleus/scss/nucleus/_sizes.scss
+++ b/engines/common/nucleus/scss/nucleus/_sizes.scss
@@ -4,10 +4,13 @@
 // Equal size fallbacks for older browsers
 @each $i, $n in ('33-3', 1/3), ('16-7', 1/6), ('14-3', 1/7), ('12-5', 1/8), ('11-1', 1/9), ('9-1', 1/11), ('8-3', 1/12) {
     .size-#{$i} {
-        -webkit-flex: 0 1 percentage($n);
-        -moz-flex: 0 1 percentage($n);
-        -ms-flex: 0 1 percentage($n);
-        flex: 0 percentage($n);
+        @include flex(percentage($n));
         width: percentage($n);
     }
 }
+
+// Support for non flex browsers
+.size-100 {
+    width: 100%;
+}
+

--- a/engines/common/nucleus/scss/nucleus/mixins/_sizes.scss
+++ b/engines/common/nucleus/scss/nucleus/mixins/_sizes.scss
@@ -1,10 +1,8 @@
 @mixin size-x {
 	@for $i from 5 through 95 {
-	.size-#{$i} { -webkit-flex: 0 1 $i * 1%;-moz-flex: 0 1 $i * 1%; -ms-flex: 0 1 $i * 1%;flex: 0 $i * 1%;width: $i * 1%; }
+	    .size-#{$i} {
+            @include flex(0 $i * 1%);
+            width: $i * 1%;
+        }
 	}
-}
-
-// Support for non flex browsers
-.size-100 {
-	width: 100%;
 }


### PR DESCRIPTION
Other sizes have `flex` value too, this one doesn't, will not affect all users, you will notice this only in specific cases. I don't think adding `flex` will adversely affect anything.

Grid With Flex
![with-flex](https://cloud.githubusercontent.com/assets/9744973/11720507/3454397c-9f68-11e5-9586-e7330e9e60b8.PNG)

Grid Without Flex
![without-flex](https://cloud.githubusercontent.com/assets/9744973/11720511/37869d2e-9f68-11e5-86bd-0fe32ea98538.PNG)
