### PR TITLE
Add flex 100% for size-100

### DIFF
--- a/engines/common/nucleus/scss/nucleus/_sizes.scss
+++ b/engines/common/nucleus/scss/nucleus/_sizes.scss
@@ -12,4 +12,5 @@
 // Support for non flex browsers
 .size-100 {
     width: 100%;
+    @include flex(0 100%);
 }


### PR DESCRIPTION
I use `.size-100` in a particle, to render a block full width, it shouldn't be flex too ?  On mobile it goes 100% because are selected all elements that contain class `size`.
