### PR TITLE
Fix for missing <body>

### DIFF
--- a/engines/common/nucleus/blueprints/page/body.yaml
+++ b/engines/common/nucleus/blueprints/page/body.yaml
@@ -42,9 +42,9 @@ form:
     body_top:
       type: textarea.textarea
       label: After <body>
-      description: Anything in this field will be appended right after <body>
+      description: Anything in this field will be appended right after the opening body tag
 
     body_bottom:
       type: textarea.textarea
       label: Before </body>
-      description: Anything in this field will be appended right before </body>
+      description: Anything in this field will be appended right before the closing body tag


### PR DESCRIPTION
Fix for missing HTML tags in the new, JS tooltips (description).