### PR TITLE
Fix for Menu Side Offset mixin

### DIFF
--- a/engines/common/nucleus/scss/nucleus/mixins/_nav.scss
+++ b/engines/common/nucleus/scss/nucleus/mixins/_nav.scss
@@ -56,9 +56,6 @@
 				    z-index: -1;
 				}
 			}
-			> .g-dropdown {
-				margin-#{$direction}: 0;
-			}
 		}
 	}
 }


### PR DESCRIPTION
Guys, I don't know why the following code was there, but it was overriding the first `margin` rule and therefore was making the mixin not to work:

```
			> .g-dropdown {
				margin-#{$direction}: 0;
			}
```