### PR TITLE
Fix: Menu item that have children is higher

### DIFF
--- a/engines/common/nucleus/scss/nucleus/_nav.scss
+++ b/engines/common/nucleus/scss/nucleus/_nav.scss
@@ -46,6 +46,7 @@
 
             .g-menu-item-container {
                 @include transition(transform .2s ease-out);
+                word-break: break-all;
             }
 
 	    	// Menu Parent Indicator on Main TopLevel


### PR DESCRIPTION

![menu](https://cloud.githubusercontent.com/assets/9744973/13612135/91b1d95c-e56e-11e5-97c2-a5296aecd6f8.PNG)
It's not visible with Hydrogen, but you can reproduce it with an empty theme, no style added.