### PR TITLE
Fix for #1260

### DIFF
--- a/src/platforms/joomla/Joomla/Category/CategoryFinder.php
+++ b/src/platforms/joomla/Joomla/Category/CategoryFinder.php
@@ -55,7 +55,8 @@ class CategoryFinder extends Finder
                 ->select('sub.id')
                 ->from('#__categories AS sub')
                 ->join('INNER', '#__categories AS this ON sub.lft > this.lft AND sub.rgt < this.rgt')
-                ->where("this.id IN ({$idList})");
+                ->where("this.id IN ({$idList})")
+                ->limit(0);
 
             if (is_numeric($levels)) {
                 $subQuery->where('sub.level <= this.level + ' . (int) $levels);


### PR DESCRIPTION
This small change will fix the problem with only 20 categories showing in Joomla category picker. (#1260)
This added line will override line 43 from `src/platforms/joomla/Joomla/Object/Finder.php`