### PR TITLE
Joomla Categories: Fix for #1260

### DIFF
--- a/platforms/joomla/com_gantry5/admin/templates/forms/fields/joomla/categories.html.twig
+++ b/platforms/joomla/com_gantry5/admin/templates/forms/fields/joomla/categories.html.twig
@@ -1,7 +1,7 @@
 {% extends 'forms/fields/input/selectize.html.twig' %}
 
 {% block global_attributes %}
-    {% set categories = field.options|default([])|merge(gantry.platform.finder('categories').find()) %}
+    {% set categories = field.options|default([])|merge(gantry.platform.finder('categories').limit(0).find()) %}
     {% set Options = field.selectize.Options %}
     {% set options = [] %}
     {% for key,category in categories %}


### PR DESCRIPTION
This small change will fix the problem with only 20 categories showing in Joomla category picker. (#1260)
Tested and working.