### PR TITLE
Fixing minor Modal bug.

### DIFF
--- a/platforms/common/scss/admin/_modal.scss
+++ b/platforms/common/scss/admin/_modal.scss
@@ -59,8 +59,7 @@ html.g5-dialog-open {
     }
 
     .g5-dialog.g5-dialog-theme-default {
-        padding-top: 10vh;
-        padding-bottom: 10vh;
+
         &.g5-closing .g5-content {
             @include animation(flyOut 0.5s);
         }
@@ -73,7 +72,7 @@ html.g5-dialog-open {
             color: $core-text;
             padding: 1rem;
             position: relative;
-            margin: 0 auto;
+            margin: 10vh auto;
             max-width: 100%;
             width: 600px;
             font-size: 1rem;


### PR DESCRIPTION
Different browsers with padding calculate heights different. Firefox and Chrome have an inconsistency of display here. Chrome respects the 10vh padding-bottom for the g5-dialog box. Firefox calculates heights differently, as such the 10vh is never adding to the bottom of the modal. To force this to render properly, because of how the box-model works with margin properties as being “addition” to heights, we convert the code to margin use. Enforcing this as an “addition” height guarentees the modal will render with the viewport margin (in additon to the modal height based on children).