### PR TITLE
Fix toggle.toggle

### DIFF
--- a/platforms/common/templates/forms/fields/toggle/toggle.html.twig
+++ b/platforms/common/templates/forms/fields/toggle/toggle.html.twig
@@ -1,23 +1,8 @@
 {% extends 'forms/' ~ layout|default('field') ~ '.html.twig' %}
 
-{% set value = (value is same as(false) ? 0 : value) %}
-
 {% block input %}
-    <div class="switch-toggle switch switch-{{ field.options|length }}">
-    {% for key, text in field.options %}
-        {% set id = "toggle_" ~ name ~ key %}
-        <input type="radio"
-               value="{{ key }}"
-               id="{{ id }}"
-               name="{{ (scope ~ name)|fieldName }}"
-                {% if field.highlight is defined %}
-                    class="{{ field.highlight == '' ~ key ? 'highlight' : '' }}"
-                {% endif %}
-                {% if '' ~ key == '' ~ value %}checked="checked" {% endif %}
-                {% if field.validate.required in ['on', 'true', 1] %}required="required"{% endif %}
-                />
-        <label for="{{ id }}">{{ text }}</label>
-        <a></a>
-    {% endfor %}
-    </div>
+    <span class="enabler" role="checkbox" aria-checked="{{ (value == 1 ? 'true' : 'false') }}">
+    <input type="hidden" name="{{ (scope ~ childName)|fieldName }}" value="{{ value }}">
+        <span class="toggle"><span class="knob"></span></span>
+    </span>
 {% endblock %}


### PR DESCRIPTION
As I [wrote on Gitter](https://gitter.im/gantry/gantry5?at=57bee8dcf066bd731b494c4f), toggle wasn't working with this YAML:
```
toggle_element:
  type: toggle.toggle
  label: Test toggle
```
Result is: Just label "Test toggle". If we inspect HTML, output is:
```
<div class="switch-toggle switch switch-0">
        </div>
```

By looking at previous code, 0 from `switch-0` means that there aren't any items in `field-options`. So, I tried this:

```
toggle_element:
  type: toggle.toggle
  label: Test toggle
  options:
    key: test
    name: test
```
Which worked! But the output was broken:
<kbd>
![screenshot_2016-08-25_14-56-55](https://cloud.githubusercontent.com/assets/15911110/17970270/30aaf38a-6ad6-11e6-96a5-78b4754e09c1.png)
</kbd>

So, I went on fixing the code and you can see the result. A normal working toggle:
<kbd>
![screenshot_2016-08-25_14-35-48](https://cloud.githubusercontent.com/assets/15911110/17970311/5e51f93c-6ad6-11e6-9686-e18a3c391ecb.png)
</kbd>

This YAML now works perfectly with it.
```
toggle_element:
  type: toggle.toggle
  label: Test toggle
```

As you can see, I removed the foreach loop, but if it's important someone can bring it back.
Output value has been checked, it returns true and false when supposed to.


Something that I forgot to do is `default: true|false` and maybe even `required: true|false`.