### PR TITLE
Fixed xml errors outside parseAssetsFunc triggering dealXmlError

### DIFF
--- a/src/classes/Gantry/Component/Twig/TwigExtension.php
+++ b/src/classes/Gantry/Component/Twig/TwigExtension.php
@@ -369,6 +369,8 @@ class TwigExtension extends \Twig_Extension
             $html = "<!doctype html>\n<html><head></head><body>{$input}</body></html>";
         }
 
+        libxml_clear_errors();
+
         $internal = libxml_use_internal_errors(true);
 
         $doc = new \DOMDocument();


### PR DESCRIPTION
if an DOM-Error occured before **parseAssetsFunc** is called the **dealXmlError** shows a error with wrong information. 