### PR TITLE
Adds the ability to select single articles by entering their IDs.

### DIFF
--- a/engines/joomla/nucleus/particles/contentarray.html.twig
+++ b/engines/joomla/nucleus/particles/contentarray.html.twig
@@ -22,7 +22,7 @@
 
     {# Content Finder #}
     {% if filter.articles %}
-        {% set article_options = filter.articles ? {id: [filter.articles|split(',')]} : {} %}
+        {% set article_options = filter.articles ? {id: [filter.articles|replace(' ', '')|split(',')]} : {} %}
         {% set article_finder = joomla.finder('content', article_options).published(1).language() %}
     {% else %}
         {% set article_finder = joomla.finder('content').category(categories).published(1).language() %}

--- a/engines/joomla/nucleus/particles/contentarray.html.twig
+++ b/engines/joomla/nucleus/particles/contentarray.html.twig
@@ -21,7 +21,12 @@
     {% set categories = joomla.finder('category', category_options).published(1).language().limit(0).find() %}
 
     {# Content Finder #}
-    {% set article_finder = joomla.finder('content').category(categories).published(1).language() %}
+    {% if filter.articles %}
+        {% set article_options = filter.articles ? {id: [filter.articles|split(',')]} : {} %}
+        {% set article_finder = joomla.finder('content', article_options).published(1).language() %}
+    {% else %}
+        {% set article_finder = joomla.finder('content').category(categories).published(1).language() %}
+    {% endif %}
 
     {% set featured = filter.featured|default('include') %}
     {% if featured == 'exclude' %}

--- a/engines/joomla/nucleus/particles/contentarray.yaml
+++ b/engines/joomla/nucleus/particles/contentarray.yaml
@@ -23,6 +23,12 @@ form:
               description: Select the categories the articles should be taken from.
               overridable: false
 
+            article.filter.articles:
+              type: input.text
+              label: Articles
+              description: Enter the Joomla articles that should be shown. It should be a list of article IDs separated with a comma (i.e. 1,2,3,4,5).
+              overridable: false
+
             article.filter.featured:
               type: select.select
               label: Featured Articles


### PR DESCRIPTION
It would also be nice to add a `pattern` for this YAML field, but I couldn't figure out the correct RegEx.

But it's not really needed because in the near future this `input.text` field should be replaced by the (not yet available) `joomla.articles` YAML field type (see https://github.com/gantry/gantry5/issues/1541 for more deatils).
