### PR TITLE
Fixed: Articles in nested categories show the whole category tree instead of just the direct category.

### DIFF
--- a/engines/joomla/nucleus/particles/contentarray.html.twig
+++ b/engines/joomla/nucleus/particles/contentarray.html.twig
@@ -96,17 +96,14 @@
                                         {% if display.category.enabled %}
                                             {% set category_link = display.category.enabled == 'link' %}
                                             <span class="g-array-item-category">
-                                                {% for category in article.categories %}
-                                                    {% if loop.last %}
-                                                        {% if category_link %}
-                                                            <a href="{{ category.route }}">
-                                                                <i class="fa fa-folder-open"></i>{{ category.title }}
-                                                            </a>
-                                                        {% else %}
-                                                            <i class="fa fa-folder-open"></i>{{ category.title }}
-                                                        {% endif %}
-                                                    {% endif %}
-                                                {% endfor %}
+                                                {% set cat = article.categories|last %}
+                                                {% if category_link %}
+                                                    <a href="{{ cat.route }}">
+                                                        <i class="fa fa-folder-open"></i>{{ cat.title }}
+                                                    </a>
+                                                {% else %}
+                                                    <i class="fa fa-folder-open"></i>{{ cat.title }}
+                                                {% endif %}
                                             </span>
                                         {% endif %}
 

--- a/engines/joomla/nucleus/particles/contentarray.html.twig
+++ b/engines/joomla/nucleus/particles/contentarray.html.twig
@@ -97,12 +97,14 @@
                                             {% set category_link = display.category.enabled == 'link' %}
                                             <span class="g-array-item-category">
                                                 {% for category in article.categories %}
-                                                    {% if category_link %}
-                                                        <a href="{{ category.route }}">
+                                                    {% if loop.last %}
+                                                        {% if category_link %}
+                                                            <a href="{{ category.route }}">
+                                                                <i class="fa fa-folder-open"></i>{{ category.title }}
+                                                            </a>
+                                                        {% else %}
                                                             <i class="fa fa-folder-open"></i>{{ category.title }}
-                                                        </a>
-                                                    {% else %}
-                                                        <i class="fa fa-folder-open"></i>{{ category.title }}
+                                                        {% endif %}
                                                     {% endif %}
                                                 {% endfor %}
                                             </span>


### PR DESCRIPTION
Currently, the "Joomla Articles" particle shows the whole category tree for articles in nested categories:

http://i.imgur.com/KPTicr4.png

I do believe that this is not what most users will expect.