### PR TITLE
Remove extra semi-colon in style attribute of label

### DIFF
--- a/platforms/joomla/plg_system_gantry5/gantry5.php
+++ b/platforms/joomla/plg_system_gantry5/gantry5.php
@@ -463,7 +463,7 @@ class plgSystemGantry5 extends JPlugin
                 $content = $content ?: 'No Particle Selected';
                 $title = $type ? ' title="Particle Type: ' . $type . '"' : '';
 
-                $html .= ' <span class="label" ' . $title . ' style="' . $colors . ';color:#fff;">' . $content . '</span>';
+                $html .= ' <span class="label" ' . $title . ' style="' . $colors . 'color:#fff;">' . $content . '</span>';
 
                 if (isset($this->modules[$id])) { unset($this->modules[$id]); }
                 else { unset($this->styles[$id]); }


### PR DESCRIPTION
`style="background:#439a86;;color:#fff;"`