### PR TITLE
Add a "global" rule for assignments per taxonomy

### DIFF
--- a/src/platforms/wordpress/classes/Gantry/WordPress/Assignments/AssignmentsTaxonomy.php
+++ b/src/platforms/wordpress/classes/Gantry/WordPress/Assignments/AssignmentsTaxonomy.php
@@ -35,6 +35,9 @@ class AssignmentsTaxonomy implements AssignmentsInterface
                 $id = $queried_object->term_id;
 
                 $rules[$taxonomy][$id] = $this->priority;
+                
+                // Assignments to a single taxonomy will have high priority
+                $rules[$taxonomy]['is_archive'] = $this->priority - 1;
             }
         }
 
@@ -61,7 +64,28 @@ class AssignmentsTaxonomy implements AssignmentsInterface
             $tax = apply_filters('g5_assignments_' . $this->type . '_' . $tax->name . '_taxonomy_object', $tax);
 
             $list[$tax->name]['label'] = sprintf($this->label, $tax->labels->name);
-            $list[$tax->name]['items'] = $this->getItems($tax);
+            $list[$tax->name]['items'][] = [
+				'name'     => '',
+				'label'    => 'General',
+				'section'  => true,
+				'disabled' => true
+			];
+
+			$list[$tax->name]['items'][] = [
+				'name'  => 'is_archive',
+				'label' => $tax->labels->name . ' - Archive View'
+			];
+
+			$list[$tax->name]['items'][] = [
+				'name'     => '',
+                // Pluralize the label (it can be "taxonomy", "archive" and maybe even something else)
+				'label'    => substr($this->type, -1, 1) === 'y' ? substr($this->type, 0, -1) . 'ies' : $this->type . 's',
+				'section'  => true,
+				'disabled' => true
+			];
+
+			$list[$tax->name]['items'] = array_merge($list[$tax->name]['items'], $this->getItems($tax) );
+		
         }
 
         return $list;


### PR DESCRIPTION
In past, if user wanted to use a custom outline for entire taxonomy, they had to assign an outline to each term.
So that meant going back to outline assignments page each time when there's a new term, and adding new assignments.

But that user won't have to do that anymore, take this for exampe:
We have `Outline A` and `Outline B`, and of course `Base Outline`. We also have a taxonomy called `Tags`. In `Tags` taxonomy, there are `Travel` and `Cuisine` terms.

`Outline A` is assigned to `Tags - Archive View`.
`Outline B` is assigned to `Travel` tag.

If we open `Travel`, we will see `Outline B`.
If we open `Cuisine`, we will see `Outline A`.

If we remove `Outline A`'s assignment, and we open `Cusine`, we will see `Base Outline`.

This will simplify assignments for taxonomies and save user's time.