### PR TITLE
Added redraw call to handle picture width problem in case scrollbar i…

### DIFF
--- a/themes/helium/common/js/owlcarousel.js
+++ b/themes/helium/common/js/owlcarousel.js
@@ -159,6 +159,8 @@
 			}
 		};
 
+        this._initialResized = false;
+
 		$.each([ 'onResize', 'onThrottledResize' ], $.proxy(function(i, handler) {
 			this._handlers[handler] = $.proxy(this[handler], this);
 		}, this));
@@ -905,6 +907,10 @@
 				left: coordinate + 'px'
 			});
 		}
+        if(!this._initialResized){
+            this.onResize();
+            this._initialResized = true;
+        }
 	};
 
 	/**


### PR DESCRIPTION
…s removed in Firefox.
Firefox shows part of the next picture as the right scroll-bar is removed when increasing the height of the window. This fix triggers redraw in this case and the picture width is increased to cover the area that was behind the scroll-bar.