### PR TITLE
Menu Item Link Target Extension - Firefox Tab Pinning Adaption

### DIFF
--- a/engines/common/nucleus/particles/menu.html.twig
+++ b/engines/common/nucleus/particles/menu.html.twig
@@ -41,7 +41,7 @@
         {% set active = menu.isActive(item) ? ' active' %}
         {% set dropdown = item.level == 1 ? ' g-' ~ item.getDropdown() %}
         {% set parent = item.children ? ' g-parent' %}
-        {% set target = item.target != 'none' ? ' target="' ~ item.target|e ~ '"' %}
+        {% set target = (item.target != '_self' or item.target_force) ? ' target="' ~ item.target|e ~ '"' %}
         {% set rel = item.rel ? ' rel="' ~ item.rel|e ~ '"' %}
 
         <li class="g-menu-item g-menu-item-type-{{ item.type }} g-menu-item-{{ item.id }}{% if not item.dropdown_hide %}{{ parent }}{% endif %}{{ active }}{{ dropdown }} {% if item.url and item.children %}{% if not item.dropdown_hide %}g-menu-item-link-parent{% endif %}{% endif %} {{ item.class|default('') }}"

--- a/engines/common/nucleus/particles/menu.html.twig
+++ b/engines/common/nucleus/particles/menu.html.twig
@@ -41,7 +41,7 @@
         {% set active = menu.isActive(item) ? ' active' %}
         {% set dropdown = item.level == 1 ? ' g-' ~ item.getDropdown() %}
         {% set parent = item.children ? ' g-parent' %}
-        {% set target = item.target != '_self' ? ' target="' ~ item.target|e ~ '"' %}
+        {% set target = item.target != 'none' ? ' target="' ~ item.target|e ~ '"' %}
         {% set rel = item.rel ? ' rel="' ~ item.rel|e ~ '"' %}
 
         <li class="g-menu-item g-menu-item-type-{{ item.type }} g-menu-item-{{ item.id }}{% if not item.dropdown_hide %}{{ parent }}{% endif %}{{ active }}{{ dropdown }} {% if item.url and item.children %}{% if not item.dropdown_hide %}g-menu-item-link-parent{% endif %}{% endif %} {{ item.class|default('') }}"

--- a/platforms/common/blueprints/menu/menuitem.yaml
+++ b/platforms/common/blueprints/menu/menuitem.yaml
@@ -59,9 +59,14 @@ form:
           label: Link Target
           placeholder: 'Select...'
           options:
-            none: None - No Target Attribution
-            _self: Self - Current Window or Tab
-            _blank: Blank - New Window or Tab
+            _self: Current Window or Tab
+            _blank: New Window or Tab
+
+        .target_force:
+          type: input.checkbox
+          label: Force Target
+          description: If checked and 'Current Window or Tab' is selected, the 'target' attribute rendering will be forced.
+          default: ''
 
         .dropdown:
           type: select.selectize

--- a/platforms/common/blueprints/menu/menuitem.yaml
+++ b/platforms/common/blueprints/menu/menuitem.yaml
@@ -59,8 +59,9 @@ form:
           label: Link Target
           placeholder: 'Select...'
           options:
-            _self: Current Window or Tab
-            _blank: New Window or Tab
+            none: None - No Target Attribution
+            _self: Self - Current Window or Tab
+            _blank: Blank - New Window or Tab
 
         .dropdown:
           type: select.selectize

--- a/platforms/grav/gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/grav/gantry5/admin/blueprints/menu/menuitem.yaml
@@ -55,8 +55,9 @@ form:
           label: Link Target
           placeholder: 'Select...'
           options:
-            _self: Current Window or Tab
-            _blank: New Window or Tab
+            none: None - No Target Attribution
+            _self: Self - Current Window or Tab
+            _blank: Blank - New Window or Tab
 
         .dropdown:
           type: select.selectize

--- a/platforms/grav/gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/grav/gantry5/admin/blueprints/menu/menuitem.yaml
@@ -61,7 +61,7 @@ form:
         .target_force:
           type: input.checkbox
           label: Force Target
-          description: If checked and 'Current Window or Tab' is selected, the 'target' attribute will be forced to be rendered.
+          description: If checked and 'Current Window or Tab' is selected, the 'target' attribute rendering will be forced.
           default: ''
 
         .dropdown:

--- a/platforms/grav/gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/grav/gantry5/admin/blueprints/menu/menuitem.yaml
@@ -55,9 +55,14 @@ form:
           label: Link Target
           placeholder: 'Select...'
           options:
-            none: None - No Target Attribution
-            _self: Self - Current Window or Tab
-            _blank: Blank - New Window or Tab
+            _self: Current Window or Tab
+            _blank: New Window or Tab
+
+        .target_force:
+          type: input.checkbox
+          label: Force Target
+          description: If checked and 'Current Window or Tab' is selected, the 'target' attribute will be forced to be rendered.
+          default: ''
 
         .dropdown:
           type: select.selectize

--- a/platforms/joomla/com_gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/joomla/com_gantry5/admin/blueprints/menu/menuitem.yaml
@@ -55,9 +55,14 @@ form:
           label: Link Target
           placeholder: 'Select...'
           options:
-            none: None - No Target Attribution
-            _self: Self - Current Window or Tab
-            _blank: Blank - New Window or Tab
+            _self: Current Window or Tab
+            _blank: New Window or Tab
+
+        .target_force:
+          type: input.checkbox
+          label: Force Target
+          description: If checked and 'Current Window or Tab' is selected, the 'target' attribute rendering will be forced.
+          default: ''
 
         .dropdown:
           type: select.selectize

--- a/platforms/joomla/com_gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/joomla/com_gantry5/admin/blueprints/menu/menuitem.yaml
@@ -55,8 +55,9 @@ form:
           label: Link Target
           placeholder: 'Select...'
           options:
-            _self: Current Window or Tab
-            _blank: New Window or Tab
+            none: None - No Target Attribution
+            _self: Self - Current Window or Tab
+            _blank: Blank - New Window or Tab
 
         .dropdown:
           type: select.selectize

--- a/platforms/wordpress/gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/wordpress/gantry5/admin/blueprints/menu/menuitem.yaml
@@ -55,8 +55,9 @@ form:
           label: Link Target
           placeholder: 'Select...'
           options:
-            _self: Current Window or Tab
-            _blank: New Window or Tab
+            none: None - No Target Attribution
+            _self: Self - Current Window or Tab
+            _blank: Blank - New Window or Tab
 
         .dropdown:
           type: select.selectize

--- a/platforms/wordpress/gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/wordpress/gantry5/admin/blueprints/menu/menuitem.yaml
@@ -61,7 +61,7 @@ form:
         .target_force:
           type: input.checkbox
           label: Force Target
-          description: If checked and 'Current Window or Tab' is selected, the 'target' attribute will be forced to be rendered.
+          description: If checked and 'Current Window or Tab' is selected, the 'target' attribute rendering will be forced.
           default: ''
 
         .dropdown:

--- a/platforms/wordpress/gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/wordpress/gantry5/admin/blueprints/menu/menuitem.yaml
@@ -55,9 +55,14 @@ form:
           label: Link Target
           placeholder: 'Select...'
           options:
-            none: None - No Target Attribution
-            _self: Self - Current Window or Tab
-            _blank: Blank - New Window or Tab
+            _self: Current Window or Tab
+            _blank: New Window or Tab
+
+        .target_force:
+          type: input.checkbox
+          label: Force Target
+          description: If checked and 'Current Window or Tab' is selected, the 'target' attribute will be forced to be rendered.
+          default: ''
 
         .dropdown:
           type: select.selectize


### PR DESCRIPTION
Hey there, first of all I hope this Pull Request doesn't create a mess. If so I will cancel it and try something else but I already did a mistake as I didn't create a branch for my last PR which is still open.

So I had to create a branch from my fork based on the last commit before I commited to my fork to don't mess up commits in the second pull request. However from the preview it seems to work as expected ;).

Please take further information concerning this Pull Request from Issue #2273. I added another option to the menu item configuration which allows us to force the `target` attribute for menu links e.g. this is relevant for the target option `_self` were currently no `target` will be rendered to the DOM.

<del>But basically the changes add another option to the link target dropdown of menu items. This means the user can differentiate between:</del>

- <del>**none:** no target attribute will be rendered for the menu item link</del>
- <del>**self:** the target will be rendered as `target="_self"`</del>

This modification is not absolutely necessary but Firefox has a "bug" (it's not clear if it will be ever fixed) which breaks the target behaviour for pinned tabs if the target attribute hasn't been specified. Hence, FF forces tabs to be opened as they were attributed with `_blank` even thought there is no `target` attribute defined on that link. This modification gives users the option to shift around this issue by forcing `target="_self"` on menu links. The default behaviour is preserved => no target attribute is rendered.

Info: Please take also a look to the deleted stuff above. I reworked the PR because it's not possible to add another option to the Gantry menu target setting since it is connected with the Joomla menu target setting. Therefore I added the 'Force Target' checkbox instead.