### PR TITLE
Joomla: optionally use content.prepare in contentarray

### DIFF
--- a/engines/joomla/nucleus/particles/contentarray.html.twig
+++ b/engines/joomla/nucleus/particles/contentarray.html.twig
@@ -112,7 +112,7 @@
                                 {% endif %}
 
                                 {% if display.text.type %}
-                                    {% set article_text = display.text.type == 'intro' ? article.introtext : article.text %}
+                                    {% set article_text = display.text.type == 'intro' ? display.text.prepare ? article.preparedIntroText : article.introtext : display.text.prepare ? article.preparedText : article.text %}
                                     <div class="g-array-item-text">
                                         {% if display.text.formatting == 'text' %}
                                             {{ article_text|truncate_text(display.text.limit)|raw }}

--- a/engines/joomla/nucleus/particles/contentarray.yaml
+++ b/engines/joomla/nucleus/particles/contentarray.yaml
@@ -145,6 +145,12 @@ form:
                 text: Plain Text
                 html: HTML
 
+            article.display.text.prepare:
+              type: input.checkbox
+              label: Prepare Content
+              description: Use Joomla Content Plugins
+              default: false
+
             article.display.title.enabled:
               type: select.select
               label: Title

--- a/src/platforms/joomla/classes/Gantry/Joomla/Content/Content.php
+++ b/src/platforms/joomla/classes/Gantry/Joomla/Content/Content.php
@@ -65,6 +65,16 @@ class Content extends AbstractObject
         return $this->introtext . ' ' . $this->fulltext;
     }
 
+    public function preparedText()
+    {
+        return \JHtml::_('content.prepare', $this->text());
+    }
+
+    public function preparedIntroText()
+    {
+        return \JHtml::_('content.prepare', $this->introtext);
+    }
+
     public function readmore()
     {
         return (bool)strlen($this->fulltext);


### PR DESCRIPTION
This allows to use the **Joomla Articles Particle** in conjunction with **Joomlas Content Plugins**.

Defaults to not use **Content Plugins** to be backward compatible.