### PR TITLE
hide submenu & indicator if no children are visible

### DIFF
--- a/engines/common/nucleus/particles/menu.html.twig
+++ b/engines/common/nucleus/particles/menu.html.twig
@@ -44,6 +44,13 @@
         {% set target = item.target != '_self' ? ' target="' ~ item.target|e ~ '"' %}
         {% set rel = item.rel ? ' rel="' ~ item.rel|e ~ '"' %}
 
+        {% set visibleChilds = false %}
+        {% for child in item.children %}
+            {% if child.visible and child.enabled and enabled|default(1) %}
+                {% set visibleChilds = true %}
+            {% endif %}
+        {% endfor %}
+
         <li class="g-menu-item g-menu-item-type-{{ item.type }} g-menu-item-{{ item.id }}{% if not item.dropdown_hide %}{{ parent }}{% endif %}{{ active }}{{ dropdown }} {% if item.url and item.children %}{% if not item.dropdown_hide %}g-menu-item-link-parent{% endif %}{% endif %} {{ item.class|default('') }}"
                 {{- SELF.getCustomWidth(item, menu, 'item', dropdown) }}
                 {%- if context.particle.renderTitles|default(0) %} title="{{ item.title }}"{% endif %}>
@@ -58,7 +65,7 @@
                     <span class="g-menu-item-content">
                         {{ SELF.displayTitle(item) }}
                     </span>
-                    {% if (item.children) and not item.dropdown_hide -%}
+                    {% if visibleChilds and not item.dropdown_hide -%}
                         <span class="g-menu-parent-indicator" data-g-menuparent=""></span>
                     {%- endif %}
                 {% else %}
@@ -69,13 +76,13 @@
                     {% else %}
                         <span class="g-separator g-menu-item-content"{{ title|raw }}>{{ SELF.displayTitle(item) }}</span>
                     {% endif %}
-                        {% if (item.children) and not item.dropdown_hide -%}
+                        {% if visibleChilds and not item.dropdown_hide -%}
                             <span class="g-menu-parent-indicator"></span>
                         {%- endif %}
                 {% endif %}
             {% if item.url %}</a>
             {% else %}</div>{% endif %}
-            {% if (item.children) -%}
+            {% if (visibleChilds) -%}
                 {{ SELF.displaySubmenu(item, menu, context, dropdown_type) }}
             {%- endif %}
         </li>

--- a/engines/common/nucleus/particles/menu.html.twig
+++ b/engines/common/nucleus/particles/menu.html.twig
@@ -48,6 +48,7 @@
         {% for child in item.children %}
             {% if child.visible and child.enabled and enabled|default(1) %}
                 {% set visibleChilds = true %}
+                {% break %}
             {% endif %}
         {% endfor %}
 

--- a/src/classes/Gantry/Component/Twig/Node/TwigNodeBreak.php
+++ b/src/classes/Gantry/Component/Twig/Node/TwigNodeBreak.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @package   Gantry5
+ * @author    RocketTheme http://www.rockettheme.com
+ * @copyright Copyright (C) 2007 - 2018 RocketTheme, LLC
+ * @license   Dual License: MIT or GNU/GPLv2 and later
+ *
+ * http://opensource.org/licenses/MIT
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * Gantry Framework code that extends GPL code is considered GNU/GPLv2 and later
+ */
+
+namespace Gantry\Component\Twig\Node;
+
+class TwigNodeBreak extends \Twig_Node
+{
+    /**
+     * Compiles the node to PHP.
+     *
+     * @param \Twig_Compiler A Twig_Compiler instance
+     */
+    public function compile(\Twig_Compiler $compiler)
+    {
+        $compiler->write("break;\n");
+    }
+}

--- a/src/classes/Gantry/Component/Twig/TokenParser/TokenParserBreak.php
+++ b/src/classes/Gantry/Component/Twig/TokenParser/TokenParserBreak.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @package   Gantry5
+ * @author    RocketTheme http://www.rockettheme.com
+ * @copyright Copyright (C) 2007 - 2018 RocketTheme, LLC
+ * @license   Dual License: MIT or GNU/GPLv2 and later
+ *
+ * http://opensource.org/licenses/MIT
+ * http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * Gantry Framework code that extends GPL code is considered GNU/GPLv2 and later
+ */
+
+namespace Gantry\Component\Twig\TokenParser;
+
+use Gantry\Component\Twig\Node\TwigNodeBreak;
+
+/**
+ * Allows to escape a for loop via {% break %}
+ *
+ * {% for post in posts %}
+ *     {% if post.id == 10 %}
+ *         {% break %}
+ *     {% endif %}
+ *     <h2>{{ post.heading }}</h2>
+ * {% endfor %}
+ *
+ * @see https://stackoverflow.com/a/40949346
+ */
+class TokenParserBreak extends \Twig_TokenParser
+{
+    public function parse(\Twig_Token $token)
+    {
+        $stream = $this->parser->getStream();
+        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        // Trick to check if we are currently in a loop.
+        $currentForLoop = 0;
+
+        for ($i = 1; true; $i++) {
+            try {
+                // if we look before the beginning of the stream
+                // the stream will throw a \Twig_Error_Syntax
+                $token = $stream->look(-$i);
+            } catch (\Twig_Error_Syntax $e) {
+                break;
+            } catch (\Exception $e) {
+                // The error handler of Twig is causing an undefined index issue
+                // https://github.com/twigphp/Twig/pull/2736
+                break;
+            }
+
+            if ($token->test(\Twig_Token::NAME_TYPE, 'for')) {
+                $currentForLoop++;
+            } else if ($token->test(\Twig_Token::NAME_TYPE, 'endfor')) {
+                $currentForLoop--;
+            }
+        }
+
+
+        if ($currentForLoop < 1) {
+            throw new \Twig_Error_Syntax(
+                'Break tag is only allowed in \'for\' loops.',
+                $stream->getCurrent()->getLine(),
+                $stream->getSourceContext()->getName()
+            );
+        }
+
+        return new TwigNodeBreak();
+    }
+
+    public function getTag()
+    {
+        return 'break';
+    }
+}

--- a/src/classes/Gantry/Component/Twig/TwigExtension.php
+++ b/src/classes/Gantry/Component/Twig/TwigExtension.php
@@ -16,6 +16,7 @@ namespace Gantry\Component\Twig;
 use Gantry\Component\Content\Document\HtmlDocument;
 use Gantry\Component\Gantry\GantryTrait;
 use Gantry\Component\Translator\TranslatorInterface;
+use Gantry\Component\Twig\TokenParser\TokenParserBreak;
 use Gantry\Component\Twig\TokenParser\TokenParserPageblock;
 use Gantry\Component\Twig\TokenParser\TokenParserAssets;
 use Gantry\Component\Twig\TokenParser\TokenParserScripts;
@@ -124,7 +125,8 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
             new TokenParserStyles,
             new TokenParserTryCatch,
             new TwigTokenParserMarkdown,
-            new TwigTokenParserSwitch
+            new TwigTokenParserSwitch,
+            new TokenParserBreak,
         ];
     }
 


### PR DESCRIPTION
I don't know if this affects any Platform other than Joomla. I just have tested Joomla.
## Current Behavior
![unfixed](https://user-images.githubusercontent.com/6141652/44392612-e85a9b00-a532-11e8-8739-9348c6870b78.gif)
Parent Items have the dropdown-indicator even when all children are unpublished or hidden.

## After this Fix
![fixed](https://user-images.githubusercontent.com/6141652/44392645-fd372e80-a532-11e8-8540-8c3b0ac2595c.gif)
The Parent Indicator is only visible if there is at least one visible and published children.

*P.s The fix is also just tested with Joomla.*