### PR TITLE
Fix Content Tabs Particle Duplicate ID

### DIFF
--- a/themes/helium/common/particles/contenttabs.html.twig
+++ b/themes/helium/common/particles/contenttabs.html.twig
@@ -12,7 +12,7 @@
                     {% for item in particle.items %}
                         <li class="g-contenttabs-tab-wrapper">
                             <span class="g-contenttabs-tab-wrapper-head">
-                                <a class="g-contenttabs-tab" href="#g-contenttabs-item-{{ loop.index }}">
+                                <a class="g-contenttabs-tab" href="#g-contenttabs-item-{{ id }}-{{ loop.index }}">
                                     <span class="g-contenttabs-tab-title">{{ item.title|raw }}</span>
                                 </a>
                             </span>
@@ -28,7 +28,7 @@
                     {% for item in particle.items %}
                         <li class="g-contenttabs-tab-wrapper">
                             <div class="g-contenttabs-tab-wrapper-body">
-                                <div id="g-contenttabs-item-{{ loop.index }}" class="g-contenttabs-content">
+                                <div id="g-contenttabs-item-{{ id }}-{{ loop.index }}" class="g-contenttabs-content">
                                     {{ item.content|raw }}
                                 </div>
                             </div>


### PR DESCRIPTION
Hey I already noticed a while ago that there is an issue with the *Content Tabs* Particle. If you add it muliple times to a page it would create duplicate IDs for `g-contenttabs-item-`. Below I added a screenshot which shows the W3C results if I add Content Tabs multiple times. 

I decided to take the particle ID to build the item ids so we get unique IDs no matter how many particles we add. Probably it would be better to address everything with some other selector and completely drop the `id=` part and use `class=` instead. However I think it is a quick fix and obvious fix.

![fix_content_tabs fw](https://user-images.githubusercontent.com/17965908/45625805-15e12880-ba8e-11e8-9291-9e5e286fa4e5.png)
. 