### PR TITLE
fix(Filesystem): keep root link if excl. target

### DIFF
--- a/src/classes/Gantry/Component/Filesystem/Folder.php
+++ b/src/classes/Gantry/Component/Filesystem/Folder.php
@@ -340,7 +340,7 @@ abstract class Folder
     protected static function doDelete($folder, $include_target = true)
     {
         // Special case for symbolic links.
-        if (is_link($folder)) {
+        if (is_link($folder) && $include_target) {
             return @unlink($folder);
         }
 


### PR DESCRIPTION
When `$include_target` is false and the root `$folder` is a symlink, don't unlink/remove it.

e.g. when recompiling CSS via `ThemeTrait::updateCss` and the compiled css folder is a symlink itself, the current code immediately attempts to unlink `css-compiled` erroneously (resulting in a failure in some cases).  Instead, symlinks should only be unlinked on subsequent calls to `doDelete` (for which `$include_target` will default to true).