### PR TITLE
filter hidden menu items

### DIFF
--- a/src/platforms/joomla/classes/Gantry/Framework/Menu.php
+++ b/src/platforms/joomla/classes/Gantry/Framework/Menu.php
@@ -264,6 +264,11 @@ class Menu extends AbstractMenu
 
             $menuItems = $this->getItemsFromPlatform($params);
 
+            // Filter hidden items
+            $menuItems = array_filter($menuItems, function($item) {
+                return $item->params->get('menu_show', null) !== 0;
+            });
+
             $itemMap = [];
             foreach ($items as $path => &$itemRef) {
                 if (isset($itemRef['id']) && is_numeric($itemRef['id'])) {


### PR DESCRIPTION
This is another approach to the issue I've tried to fix in #2348, but this will only affect Joomla.
It will change the menu editor behavior slightly, because hidden menu items won't show up anymore.
But that's the same for the editor in Grav.

