### PR TITLE
Add logo image max height

### DIFF
--- a/engines/common/nucleus/particles/logo.html.twig
+++ b/engines/common/nucleus/particles/logo.html.twig
@@ -5,14 +5,15 @@
     {% if (url == gantry.siteUrl()) %}{% set rel='rel="home"' %}{% endif %}
     {% set class=(particle.class ? 'class="'~ particle.class ~'"') %}
     {% set image = url(particle.image) %}
-    
+    {% set height = particle.height ? 'style="max-height: ' ~ particle.height ~ '"' %}
+
     {% if particle.link == true %}
         <a href="{{ url }}" target="{{ particle.target|default('_self') }}" title="{{ particle.text }}" {{ rel|default('')|raw }} {{ class|default('')|raw }}>
     {% else %}<div {{ class|default('')|raw }}>{% endif %}
         {% if particle.svg is not empty %}
             {{ particle.svg|raw }}
         {% elseif image %}
-            <img src="{{ url(particle.image) }}" alt="{{ particle.text }}" />
+            <img src="{{ url(particle.image) }}" {{ height|default('')|raw }} alt="{{ particle.text }}" />
         {% else %}
             {{ particle.text|default('Logo') }}
         {% endif %}

--- a/engines/common/nucleus/particles/logo.yaml
+++ b/engines/common/nucleus/particles/logo.yaml
@@ -38,7 +38,7 @@ form:
 
     height:
       type: input.text
-      label: Image Height
+      label: Maximum Height
       description: Set image max. height in rem, em, px, or percentage unit values
       pattern: '\d+(\.\d+){0,1}(rem|em|ex|ch|vw|vh|vmin|vmax|%|px|cm|mm|in|pt|pc)'
 

--- a/engines/common/nucleus/particles/logo.yaml
+++ b/engines/common/nucleus/particles/logo.yaml
@@ -35,7 +35,13 @@ form:
       type: input.imagepicker
       label: Image
       description: Select desired logo image.
-      
+
+    height:
+      type: input.text
+      label: Image Height
+      description: Set image max. height in rem, em, px, or percentage unit values
+      pattern: '\d+(\.\d+){0,1}(rem|em|ex|ch|vw|vh|vmin|vmax|%|px|cm|mm|in|pt|pc)'
+
     link:
       type: input.checkbox
       label: Link


### PR DESCRIPTION
It works with logo images only, as svg size shouldn't be set using width / height. The default value is empty, it won't affect existing websites. I tested with Helium theme.

ref: https://github.com/gantry/gantry5/issues/2399