### PR TITLE
Extension of owlcarousel particle - planned / timed slides

### DIFF
--- a/themes/helium/common/particles/owlcarousel.html.twig
+++ b/themes/helium/common/particles/owlcarousel.html.twig
@@ -9,9 +9,15 @@
 
             {% for item in particle.items %}
                 {% set showItem = item.showItem|default('yes') %}
-                {% if showItem == 'once' or showItem == 'annual' %}
-                    {% set dFormat = (showItem == 'once') ? 'Y-m-d' : 'm-d' %}
-                    {% if item.startDate|date(dFormat) <= "now"|date(dFormat) and item.endDate|date(dFormat) >= "now"|date(dFormat) %}
+                {% set format = (showItem == 'once') ? 'Y-m-d' : 'm-d' %}
+                {% set start, now, end = item.startDate|date(format), "now"|date(format), item.endDate|date(format) %}
+                {% if showItem == 'once' %}
+                    {% if start <= now and end >= now %}
+                        {% set showItem = 'yes' %}
+                    {% endif %}       
+                {% elseif showItem == 'annual' %}
+                    {% if (start <= end and start <= now and end >= now) or 
+                          (start > end and (start <= now or end >= now)) %}
                         {% set showItem = 'yes' %}
                     {% endif %}
                 {% endif %}

--- a/themes/helium/common/particles/owlcarousel.html.twig
+++ b/themes/helium/common/particles/owlcarousel.html.twig
@@ -8,7 +8,14 @@
         <div id="g-owlcarousel-{{ id }}" class="g-owlcarousel owl-carousel {% if particle.imageOverlay == 'enable' %}has-color-overlay{% endif %}">
 
             {% for item in particle.items %}
-                {% if not item.disable %}
+                {% set showItem = item.showItem|default('yes') %}
+                {% if showItem == 'once' or showItem == 'annual' %}
+                    {% set dFormat = (showItem == 'once') ? 'Y-m-d' : 'm-d' %}
+                    {% if item.startDate|date(dFormat) <= "now"|date(dFormat) and item.endDate|date(dFormat) >= "now"|date(dFormat) %}
+                        {% set showItem = 'yes' %}
+                    {% endif %}
+                {% endif %}
+                {% if showItem == 'yes' %}
                     <div class="g-owlcarousel-item {{ item.class|e }}">
                         <div class="g-owlcarousel-item-wrapper">
                             <div class="g-owlcarousel-item-img">

--- a/themes/helium/common/particles/owlcarousel.yaml
+++ b/themes/helium/common/particles/owlcarousel.yaml
@@ -109,8 +109,21 @@ form:
           label: Button Class
           description: Input the button class.
           default: 'button-outline'
-        .disable:
-          type: input.checkbox
-          label: Disable
-          description: Disables the item on the front end.
-          default: false
+        .showItem:
+          type: select.select
+          label: Show Item
+          description: Select the front end rendering behaviour for the item.
+          default: yes
+          options:
+            yes: Yes
+            no: No
+            once: Once
+            annual: Annual
+        .startDate:
+          type: input.date
+          label: Start Date
+          description: Select the date when the item should be first shown (only for 'annual' and 'once').
+        .endDate:
+          type: input.date
+          label: End Date
+          description: Select the date when the item should be last shown (only for 'annual' and 'once').


### PR DESCRIPTION
@newkind @mahagr 

This PR can be seen as an addition to a previous merged PR (#2286) where I added the disable functionality for owlcarousel slides. I now had the time to create a more sophisticated solution for the Particle which I already had in mind for months.

It is fine to have slides that can be disabled on demand but even better for maintenance of a websites would be to have specific time intervals to show slides. However, that still wasn't enough, it should be possible to define recurring events (e.g. new year, x-mas, holidays, whatever) and not within a specific one-time frame.

Therefore I extended the previous behaviour so it is still possible to enable / disable items like before. Additionally, I added two improved options which allow us to show slides on a one-time or an annually event basis. To sum things up we have now the following options to show slides:

- **yes:** show always
- **no:** show never
- **annual:** show every year when the current date is in the time frame
- **once:** show only when the current date is in the exact time frame