### PR TITLE
Use Gantry classes instead of Bootstrap classes

### DIFF
--- a/engines/joomla/nucleus/twig/component.html.twig
+++ b/engines/joomla/nucleus/twig/component.html.twig
@@ -13,8 +13,8 @@
 
 {% block page_layout %}
     {% do gantry.theme.joomla(true) %}
-    <div class="platform-content row-fluid">
-        <div class="span12">
+    <div class="platform-content g-grid">
+        <div class="g-block size-100">
             <jdoc:include type="message" />
             <jdoc:include type="component" />
         </div>


### PR DESCRIPTION
This update uses the Gantry5 classes and grid instead of the Bootstrap one.  I don't know why Bootstrap was used in the first place, maybe there is a reason, in which case please feed back.