### PR TITLE
Update contentarray.html.twig

### DIFF
--- a/engines/wordpress/nucleus/particles/contentarray.html.twig
+++ b/engines/wordpress/nucleus/particles/contentarray.html.twig
@@ -26,7 +26,7 @@
     {% set query_parameters = query_parameters|merge({'cat': filter.categories|replace({' ': ',', ', ': ','})}) %}
 {% endif %}
 
-{% set posts = wordpress.call('Timber::query_posts', query_parameters) %}
+{% set posts = wordpress.call('Timber::get_posts', query_parameters) %}
 {% set total = posts.get_pagination([]).total|abs %}
 {% set total = max(posts|length, (total * max(0, limit.total)) - 1) %}
 


### PR DESCRIPTION
Instead of the query_posts it should be used get_posts. It collides with custom post types if we use query_posts then it will say that custom post type is a post and not what it is.

Fixes #2148 