### PR TITLE
Add option to disable particle items

### DIFF
--- a/engines/common/nucleus/particles/social.html.twig
+++ b/engines/common/nucleus/particles/social.html.twig
@@ -9,12 +9,14 @@
     {% if particle.title %}<h2 class="g-title">{{ particle.title|raw }}</h2>{% endif %}
     <div class="g-social {{ particle.css.class }}">
         {% for item in particle.items %}
-            {% set title = (item.title is not empty) ? item.title|e : item.text|e %}
-            {% set titleAttrib = (title is not empty) ? ' title="' ~ title ~ '" aria-label="' ~ title ~ '"' : '' %}
-            <a href="{{ item.link|e }}"{{ targetAttrib|raw }}{{ titleAttrib|raw }}>
-                {% if particle.display in ['both', 'icons_only'] %}<span class="{{ item.icon|e }}"></span>{% endif %}
-                {% if particle.display in ['both', 'text_only'] %}<span class="g-social-text">{{ item.text|e }}</span>{% endif %}
-            </a>
+            {% if item.enabled %}
+                {% set title = (item.title is not empty) ? item.title|e : item.text|e %}
+                {% set titleAttrib = (title is not empty) ? ' title="' ~ title ~ '" aria-label="' ~ title ~ '"' : '' %}
+                <a href="{{ item.link|e }}"{{ targetAttrib|raw }}{{ titleAttrib|raw }}>
+                    {% if particle.display in ['both', 'icons_only'] %}<span class="{{ item.icon|e }}"></span>{% endif %}
+                    {% if particle.display in ['both', 'text_only'] %}<span class="g-social-text">{{ item.text|e }}</span>{% endif %}
+                </a>
+            {% endif %}
         {% endfor %}
     </div>
 {% endblock %}

--- a/engines/common/nucleus/particles/social.yaml
+++ b/engines/common/nucleus/particles/social.yaml
@@ -59,6 +59,12 @@ form:
       ajax: true
 
       fields:
+        .enabled:
+          type: input.checkbox
+          label: Enabled
+          description: Enables or disables this item.
+          default: true
+
         .name:
           type: input.text
           label: Name

--- a/themes/helium/common/particles/contentcubes.html.twig
+++ b/themes/helium/common/particles/contentcubes.html.twig
@@ -9,51 +9,53 @@
         <div class="cube-items-wrapper">
 
             {% for item in particle.items %}
-                <div class="item image-position-{{ item.imageposition }} cube-row g-grid">
-                    <div class="g-block size-50">
-                        {% if item.image %}
-                            <div class="cube-image-wrapper">
-                                <img src="{{ url(item.image)|e }}" alt="{{ item.title|e }}" class="cube-image" />
-                            </div>
-                        {% endif %}
-                    </div>
-
-                    <div class="g-block size-50">
-                        <div class="cube-content-wrapper">
-                            {% if item.label %}
-                                <div class="item-label">{{ item.label|e }}</div>
-                            {% endif %}
-
-                            <div class="item-title">
-                                {% if item.link %}
-                                <a target="{{ item.buttontarget|default('_self')|e }}" class="item-link {{ item.buttonclass|e }}" href="{{ item.link|e }}">
-                                    {% endif %}
-
-                                    {{ item.title|e }}
-
-                                    {% if item.link %}
-                                    <span class="item-link-text">{{ item.linktext|raw }}</span>
-                                </a>
-                                {% endif %}
-                            </div>
-
-                            {% if item.tags %}
-                                <div class="item-tags">
-
-                                    {% for tag in item.tags %}
-                                        <span class="tag">
-                                            <a target="{{ tag.target|default('_self')|e }}" href="{{ tag.link|e }}">
-                                                {% if tag.icon %}<i class="{{ tag.icon }}"></i> {% endif %}
-                                                {{ tag.text|raw }}
-                                            </a>
-                                        </span>
-                                    {% endfor %}
-
+                {% if item.enabled %}
+                    <div class="item image-position-{{ item.imageposition }} cube-row g-grid">
+                        <div class="g-block size-50">
+                            {% if item.image %}
+                                <div class="cube-image-wrapper">
+                                    <img src="{{ url(item.image)|e }}" alt="{{ item.title|e }}" class="cube-image" />
                                 </div>
                             {% endif %}
                         </div>
+
+                        <div class="g-block size-50">
+                            <div class="cube-content-wrapper">
+                                {% if item.label %}
+                                    <div class="item-label">{{ item.label|e }}</div>
+                                {% endif %}
+
+                                <div class="item-title">
+                                    {% if item.link %}
+                                    <a target="{{ item.buttontarget|default('_self')|e }}" class="item-link {{ item.buttonclass|e }}" href="{{ item.link|e }}">
+                                        {% endif %}
+
+                                        {{ item.title|e }}
+
+                                        {% if item.link %}
+                                        <span class="item-link-text">{{ item.linktext|raw }}</span>
+                                    </a>
+                                    {% endif %}
+                                </div>
+
+                                {% if item.tags %}
+                                    <div class="item-tags">
+
+                                        {% for tag in item.tags %}
+                                            <span class="tag">
+                                                <a target="{{ tag.target|default('_self')|e }}" href="{{ tag.link|e }}">
+                                                    {% if tag.icon %}<i class="{{ tag.icon }}"></i> {% endif %}
+                                                    {{ tag.text|raw }}
+                                                </a>
+                                            </span>
+                                        {% endfor %}
+
+                                    </div>
+                                {% endif %}
+                            </div>
+                        </div>
                     </div>
-                </div>
+                {% endif %}
             {% endfor %}
 
         </div>

--- a/themes/helium/common/particles/contentcubes.yaml
+++ b/themes/helium/common/particles/contentcubes.yaml
@@ -35,6 +35,11 @@ form:
       ajax: true
 
       fields:
+        .enabled:
+          type: input.checkbox
+          label: Enabled
+          description: Enables or disables this item.
+          default: true
         .name:
           type: input.text
         .image:

--- a/themes/helium/common/particles/contenttabs.html.twig
+++ b/themes/helium/common/particles/contenttabs.html.twig
@@ -10,13 +10,15 @@
                 <ul class="g-contenttabs-tab-wrapper-container">
 
                     {% for item in particle.items %}
-                        <li class="g-contenttabs-tab-wrapper">
-                            <span class="g-contenttabs-tab-wrapper-head">
-                                <a class="g-contenttabs-tab" href="#g-contenttabs-item-{{ id }}-{{ loop.index }}">
-                                    <span class="g-contenttabs-tab-title">{{ item.title|raw }}</span>
-                                </a>
-                            </span>
-                        </li>
+                        {% if item.enabled %}
+                            <li class="g-contenttabs-tab-wrapper">
+                                <span class="g-contenttabs-tab-wrapper-head">
+                                    <a class="g-contenttabs-tab" href="#g-contenttabs-item-{{ id }}-{{ loop.index }}">
+                                        <span class="g-contenttabs-tab-title">{{ item.title|raw }}</span>
+                                    </a>
+                                </span>
+                            </li>
+                        {% endif %}
                     {% endfor %}
 
                 </ul>
@@ -26,13 +28,15 @@
                 <ul class="g-contenttabs-content-wrapper-container">
 
                     {% for item in particle.items %}
-                        <li class="g-contenttabs-tab-wrapper">
-                            <div class="g-contenttabs-tab-wrapper-body">
-                                <div id="g-contenttabs-item-{{ id }}-{{ loop.index }}" class="g-contenttabs-content">
-                                    {{ item.content|raw }}
+                        {% if item.enabled %}
+                            <li class="g-contenttabs-tab-wrapper">
+                                <div class="g-contenttabs-tab-wrapper-body">
+                                    <div id="g-contenttabs-item-{{ id }}-{{ loop.index }}" class="g-contenttabs-content">
+                                        {{ item.content|raw }}
+                                    </div>
                                 </div>
-                            </div>
-                        </li>
+                            </li>
+                        {% endif %}
                     {% endfor %}
 
                 </ul>

--- a/themes/helium/common/particles/contenttabs.yaml
+++ b/themes/helium/common/particles/contenttabs.yaml
@@ -48,6 +48,11 @@ form:
       ajax: true
 
       fields:
+        .enabled:
+          type: input.checkbox
+          label: Enabled
+          description: Enables or disables this item.
+          default: true
         .title:
           type: input.text
           label: Title

--- a/themes/helium/common/particles/horizontalmenu.html.twig
+++ b/themes/helium/common/particles/horizontalmenu.html.twig
@@ -5,9 +5,11 @@
     <ul class="g-horizontalmenu {{ particle.class|e }}">
 
         {% for item in particle.items %}
-            <li>
-                <a target="{{ particle.target }}" href="{{ item.link|e }}" title="{{ item.text }}">{{ item.text }}</a>
-            </li>
+            {% if item.enabled %}
+                <li>
+                    <a target="{{ particle.target }}" href="{{ item.link|e }}" title="{{ item.text }}">{{ item.text }}</a>
+                </li>
+            {% endif %}
         {% endfor %}
 
     </ul>

--- a/themes/helium/common/particles/horizontalmenu.yaml
+++ b/themes/helium/common/particles/horizontalmenu.yaml
@@ -39,6 +39,11 @@ form:
       ajax: true
 
       fields:
+        .enabled:
+          type: input.checkbox
+          label: Enabled
+          description: Enables or disables this item.
+          default: true
         .name:
           type: input.text
           label: Name

--- a/themes/hydrogen/common/particles/sample.html.twig
+++ b/themes/hydrogen/common/particles/sample.html.twig
@@ -14,15 +14,17 @@
 		</div>
 		<div class="g-grid">
 			{% for sample in particle.samples %}
-				<div {% if sample.id %}id="{{ sample.id|e }}"{% endif %}
-					 class="g-block {{ sample.class }} {{ sample.variations }}">
-					<div class="g-content">
-						<i class="{{ sample.icon }} sample-icons"></i>
-						<h4>{{ sample.title|raw }}</h4>
-						{{ sample.subtitle|raw }}
-						{{ sample.description|raw }}
+				{% if item.enabled %}
+					<div {% if sample.id %}id="{{ sample.id|e }}"{% endif %}
+						 class="g-block {{ sample.class }} {{ sample.variations }}">
+						<div class="g-content">
+							<i class="{{ sample.icon }} sample-icons"></i>
+							<h4>{{ sample.title|raw }}</h4>
+							{{ sample.subtitle|raw }}
+							{{ sample.description|raw }}
+						</div>
 					</div>
-				</div>
+				{% endif %}
 			{% endfor %}
 		</div>
 	</div>

--- a/themes/hydrogen/common/particles/sample.yaml
+++ b/themes/hydrogen/common/particles/sample.yaml
@@ -57,6 +57,12 @@ form:
       overridable: false
 
       fields:
+        .enabled:
+          type: input.checkbox
+          label: Enabled
+          description: Enables or disables this item.
+          default: true
+
         .icon:
           type: input.icon
           label: Icon


### PR DESCRIPTION
**I will recreate that PR don't merge**

I added an additional field to all relevant particles which contain a `collection.list` to allow that a user can selectively disable certain front-end items. The idea for this adaption comes from @yellowwebmonkey. The particles which I found and come into question are:

* Social
* Sample (Hydrogen)
* Content Cubes
* Horizontal Menu
* Content Tabs

Please also see the PR #2286 which contains the same functionality for the Owl Carousel.