### PR TITLE
Disable menu with CSS on mobile devices

### DIFF
--- a/engines/common/nucleus/particles/menu.html.twig
+++ b/engines/common/nucleus/particles/menu.html.twig
@@ -123,7 +123,7 @@
 {% import _self as macro %}
 
 {% if menu.root.count() %}
-<nav class="g-main-nav" role="navigation"{{ particle.mobileTarget ? ' data-g-mobile-target' : '' }} data-g-hover-expand="{{ particle.hoverExpand|default('true') ? 'true': 'false' }}">
+<nav class="g-main-nav{{ particle.disableMobile ? ' g-hide-mobile' : '' }}" role="navigation"{{ particle.mobileTarget ? ' data-g-mobile-target' : '' }} data-g-hover-expand="{{ particle.hoverExpand|default('true') ? 'true': 'false' }}">
     <ul class="g-toplevel">
         {{ macro.displayItems(menu.root, menu, _context) }}
     </ul>

--- a/engines/wordpress/nucleus/particles/menu.yaml
+++ b/engines/wordpress/nucleus/particles/menu.yaml
@@ -70,3 +70,9 @@ form:
       label: Force Target Attribute
       description: 'Adds ''target="_self"'' attribute to all menu items. Fixes an issue with pinned tabs in Firefox where external links always open in a new tab.'
       default: 0
+
+    disableMobile:
+      type: input.checkbox
+      label: Disable on Mobile
+      description: Check this field to completely disable the menu on mobile devices. This prevents menu flickering but you might end with no menu when JS is not supported by the respective device. 
+      default: 0

--- a/themes/hydrogen/common/scss/hydrogen/_nav.scss
+++ b/themes/hydrogen/common/scss/hydrogen/_nav.scss
@@ -93,6 +93,13 @@
 	}
 }
 
+.g-main-nav.g-hide-mobile{
+    @include breakpoint(mobile-only) {
+        display: none;
+        visibility: hidden;
+    }
+}
+
 #g-navigation, #g-header {
 	.align-left {
 		.g-toplevel {


### PR DESCRIPTION
This PR is based on the issue #2536. It adds to the menu particle a checkbox option to completely disable the menu on mobile devices (`mobile-only`). For further information read the referenced issue which explains why this might be useful for users (flickering).

Hence, this gives the user the option to decide whether he wants to risk ending with no menu on mobile devices when no JS is supported but prevents the main menu to be rendered during page load (which is still an annoying issue for many people). This might be a good compromise because the default behaviour is maintained and there is an option to decide whether the risk should be taken (also explained in the field description).

Note: The SCSS added might not be added on the right spot and / or applied only for Hydrogen. Any input would be helpful I will change the PR properly if I know to do it correctly.

@n8solutions