### PR TITLE
Added Font Awesome page setting with disable switch

### DIFF
--- a/engines/common/nucleus/blueprints/page/fontawesome.yaml
+++ b/engines/common/nucleus/blueprints/page/fontawesome.yaml
@@ -1,0 +1,12 @@
+name: Font Awesome Settings
+description: Configuration for Font Awesome icon set and toolkit. 
+type: global
+
+form:
+  fields:
+  
+    enable:
+      type: enable.enable
+      label: Enable
+      description: Enable or disable the loading of the Font Awesome icon library on the frontend. This is useful if you want to manually add a different version of the library (e.g. v5.x).
+      default: 1

--- a/engines/common/nucleus/templates/page_head.html.twig
+++ b/engines/common/nucleus/templates/page_head.html.twig
@@ -3,7 +3,9 @@
 
 {% assets with { priority: 10 } %}
     {% block head_stylesheets -%}
-        <link rel="stylesheet" href="gantry-assets://css/font-awesome.min.css" type="text/css"/>
+        {% if gantry.config.page.fontawesome.enable|default(1) %}
+            <link rel="stylesheet" href="gantry-assets://css/font-awesome.min.css" type="text/css"/>
+        {% endif %}
         <link rel="stylesheet" href="gantry-engine://css-compiled/nucleus.css" type="text/css"/>
         {% for scss in gantry.theme.configuration.css.persistent|default(gantry.theme.configuration.css.files) %}
         <link rel="stylesheet" href="{{ scss }}.scss" type="text/css"/>


### PR DESCRIPTION
The discussion on Font Awesome 4 and the successor Font Awesome 5 is already open for quite some time (#2196). As a first step towards supporting v5 I would recommend adding at least a switch to disable the front-end loading of the Font Awesome 4 library. This allows users to easier switch versions on the front-end without the need to override core files or double loading both versions. I decided to create a new panel within the Page Settings. It might not be the best place to handle that but probably more options would be necessary in the future concerning icons or especially Font Awesome so a separate panel sounds useful to me.

![grafik](https://user-images.githubusercontent.com/17965908/64763727-ea7a0800-d540-11e9-8f81-aad8fe017d58.png)

I added a screenshot to show what the PR does. This also would make things easier when writing an Atom which supports FA5. Because no need for me as a developer to touch core files. I can completely rely on that setting + an Atom which handles everything else. This also gives the community the power to handle FA5 without the necessity to wait on back-end support.

@mahagr @marktaylor46 @newkind @yellowwebmonkey @n8solutions