### PR TITLE
Add option to define custom attributes on menu items

### DIFF
--- a/engines/common/nucleus/particles/menu.html.twig
+++ b/engines/common/nucleus/particles/menu.html.twig
@@ -43,10 +43,18 @@
         {% set parent = item.children ? ' g-parent' %}
         {% set target = (item.target != '_self' or context.particle.forceTarget) ? ' target="' ~ item.target|e ~ '"' %}
         {% set rel = item.rel ? ' rel="' ~ item.rel|e ~ '"' %}
+        {% set attributes = '' %}
+        {% if item.attributes %}
+            {% for attribute in item.attributes %}
+                {% for key, value in attribute %}
+                    {% set attributes = attributes ~ ' ' ~ key|e ~ '="' ~ value|e('html_attr') ~ '"' %}
+                {% endfor %}
+            {% endfor %}
+        {% endif %}
 
         <li class="g-menu-item g-menu-item-type-{{ item.type }} g-menu-item-{{ item.id }}{% if not item.dropdown_hide %}{{ parent }}{% endif %}{{ active }}{{ dropdown }} {% if item.url and item.children %}{% if not item.dropdown_hide %}g-menu-item-link-parent{% endif %}{% endif %} {{ item.class|default('') }}"
                 {{- self.getCustomWidth(item, menu, 'item', dropdown) }}
-                {%- if context.particle.renderTitles|default(0) %} title="{{ item.title }}"{% endif %}>
+                {%- if context.particle.renderTitles|default(0) %} title="{{ item.title }}"{% endif %}{{attributes|raw}}>
             {% if item.url %}<a class="g-menu-item-container{{ item.anchor_class ? ' ' ~ item.anchor_class }}" href="{{ item.url }}{{ item.hash }}"{{ (title ~ label ~ target ~ rel)|raw }}>
             {% else %}<div class="g-menu-item-container{{ item.anchor_class ? ' ' ~ item.anchor_class }}" data-g-menuparent=""{{ label|raw }}>{% endif %}
                 {% if item.image %}

--- a/platforms/common/blueprints/menu/menuitem.yaml
+++ b/platforms/common/blueprints/menu/menuitem.yaml
@@ -44,6 +44,14 @@ form:
           type: input.text
           label: Link
 
+        .attributes:
+          type: collection.keyvalue
+          label: Tag Attributes
+          description: Additional attributes for the menu item.
+          key_placeholder: Key (e.g. style, name, ...)
+          value_placeholder: Value
+          exclude: ['id', 'class']
+
         .hash:
           type: input.text
           label: Append Hash

--- a/platforms/grav/gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/grav/gantry5/admin/blueprints/menu/menuitem.yaml
@@ -40,6 +40,14 @@ form:
           label: Link
           disabled: true
 
+        .attributes:
+          type: collection.keyvalue
+          label: Tag Attributes
+          description: Additional attributes for the menu item.
+          key_placeholder: Key (e.g. style, name, ...)
+          value_placeholder: Value
+          exclude: ['id', 'class']
+
         .hash:
           type: input.text
           label: Append Hash

--- a/platforms/joomla/com_gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/joomla/com_gantry5/admin/blueprints/menu/menuitem.yaml
@@ -40,6 +40,14 @@ form:
           label: Link
           disabled: true
 
+        .attributes:
+          type: collection.keyvalue
+          label: Tag Attributes
+          description: Additional attributes for the menu item.
+          key_placeholder: Key (e.g. style, name, ...)
+          value_placeholder: Value
+          exclude: ['id', 'class']
+
         .hash:
           type: input.text
           label: Append Hash

--- a/platforms/wordpress/gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/wordpress/gantry5/admin/blueprints/menu/menuitem.yaml
@@ -40,6 +40,14 @@ form:
           label: Link
           disabled: true
 
+        .attributes:
+          type: collection.keyvalue
+          label: Tag Attributes
+          description: Additional attributes for the menu item.
+          key_placeholder: Key (e.g. style, name, ...)
+          value_placeholder: Value
+          exclude: ['id', 'class']
+
         .hash:
           type: input.text
           label: Append Hash


### PR DESCRIPTION
@jozwkat @mahagr @n8solutions There is a demand to define custom attributes on menu items and I think this a good thing to have. Even though I never needed it. Nonetheless I decided to create a pull request to serve this feature request. This PR adds another option to the Gantry menu configuration that allows to add additional attributes per menu item (see also screenshot).

![grafik](https://user-images.githubusercontent.com/17965908/64766633-9d009980-d546-11e9-8605-2e320c7f4177.png)
