### PR TITLE
Unauthorised links and article authorisation fix

### DIFF
--- a/src/platforms/joomla/classes/Gantry/Joomla/Category/CategoryFinder.php
+++ b/src/platforms/joomla/classes/Gantry/Joomla/Category/CategoryFinder.php
@@ -106,7 +106,7 @@ class CategoryFinder extends Finder
         $user = \JFactory::getUser();
         $groups = $user->getAuthorisedViewLevels();
 
-        return $this->where('a.access', 'IN', $groups);
+        return $this;
     }
 
     public function extension($extension)

--- a/src/platforms/joomla/classes/Gantry/Joomla/Content/ContentFinder.php
+++ b/src/platforms/joomla/classes/Gantry/Joomla/Content/ContentFinder.php
@@ -111,20 +111,21 @@ class ContentFinder extends Finder
         $nullDate = $this->db->quote($this->db->getNullDate());
         $nowDate = $this->db->quote(\JFactory::getDate()->toSql());
 
+		$groups = $user->getAuthorisedViewLevels();
+		$comma_separated_groups = implode(",", $groups);
+
         // Filter by start and end dates.
         if (!$user->authorise('core.edit.state', 'com_content') && !$user->authorise('core.edit', 'com_content')) {
             $this->query
                 ->where("(a.publish_up = {$nullDate} OR a.publish_up <= {$nowDate})")
                 ->where("(a.publish_down = {$nullDate} OR a.publish_down >= {$nowDate})")
                 ->where("a.state >= 1")
+				->where("(a.access IN ({$comma_separated_groups}) OR JSON_EXTRACT(a.attribs, '$.show_noauth') =1)")
             ;
         }
 
-        $groups = $user->getAuthorisedViewLevels();
-
-        $this->query->join('INNER', '#__categories AS c ON c.id = a.catid');
-
-        return $this->where('a.access', 'IN', $groups)->where('c.access', 'IN', $groups);
+		$this->query->join('INNER', '#__categories AS c ON c.id = a.catid');
+		return $this;
     }
 
     protected function addToGroup($key, $ids, $include = true)

--- a/src/platforms/joomla/classes/Gantry/Joomla/Content/ContentFinder.php
+++ b/src/platforms/joomla/classes/Gantry/Joomla/Content/ContentFinder.php
@@ -120,7 +120,9 @@ class ContentFinder extends Finder
                 ->where("(a.publish_up = {$nullDate} OR a.publish_up <= {$nowDate})")
                 ->where("(a.publish_down = {$nullDate} OR a.publish_down >= {$nowDate})")
                 ->where("a.state >= 1")
-				->where("(a.access IN ({$comma_separated_groups}) OR JSON_EXTRACT(a.attribs, '$.show_noauth') =1)")
+				->where("(a.access IN ({$comma_separated_groups}) OR 
+                (CASE WHEN JSON_EXTRACT(attribs, '$.show_noauth') IS NULL THEN (select JSON_EXTRACT(params, '$.show_noauth')  FROM #__extensions where element='com_content')
+                ELSE JSON_EXTRACT(attribs, '$.show_noauth') END) =1)")
             ;
         }
 

--- a/src/platforms/joomla/classes/Gantry/Joomla/Content/ContentFinder.php
+++ b/src/platforms/joomla/classes/Gantry/Joomla/Content/ContentFinder.php
@@ -120,9 +120,10 @@ class ContentFinder extends Finder
                 ->where("(a.publish_up = {$nullDate} OR a.publish_up <= {$nowDate})")
                 ->where("(a.publish_down = {$nullDate} OR a.publish_down >= {$nowDate})")
                 ->where("a.state >= 1")
-				->where("(a.access IN ({$comma_separated_groups}) OR 
-                (CASE WHEN JSON_EXTRACT(attribs, '$.show_noauth') IS NULL THEN (select JSON_EXTRACT(params, '$.show_noauth')  FROM #__extensions where element='com_content')
-                ELSE JSON_EXTRACT(attribs, '$.show_noauth') END) =1)")
+			    ->where("(a.access IN ({$comma_separated_groups}) OR 
+                    ( CASE WHEN JSON_UNQUOTE(JSON_EXTRACT(attribs, '$.show_noauth' )) IS NULL OR JSON_UNQUOTE(JSON_EXTRACT(attribs, '$.show_noauth' )) ='' THEN 
+                    JSON_UNQUOTE((select JSON_EXTRACT(params, '$.show_noauth') FROM josvz_extensions where element='com_content'))
+                    ELSE JSON_UNQUOTE(JSON_EXTRACT(attribs, '$.show_noauth')) END) =1)")
             ;
         }
 


### PR DESCRIPTION
#2542 
Good Changes
- When retrieving articles the c.access won`t be checked( the article access is leading)
- unauthorised link setting is now taken into account.

questional change:
- Removed category acces level check in categoryfinder.php

Instead of removing the acces level check for category There should be a way to retrieve articles from given category id which doesn't take the category acces level in to account.
The change that i made is a problem if there are particles that want to show category`s with different access levels 