### PR TITLE
Added Tags filter for Joomla! articles

### DIFF
--- a/src/platforms/joomla/classes/Gantry/Joomla/Content/ContentFinder.php
+++ b/src/platforms/joomla/classes/Gantry/Joomla/Content/ContentFinder.php
@@ -148,4 +148,16 @@ class ContentFinder extends Finder
             }
         }
     }
+
+    public function tags($tagIds = [])
+    {
+        if (empty($tagIds['id'][0])) {
+            return $this;
+        }
+
+        $tagIdsArray = $tagIds['id'][0];
+        $this->query->join('INNER', '#__contentitem_tag_map AS t ON t.content_item_id  = a.id');
+
+        return $this->where('t.tag_id', 'IN', $tagIdsArray);
+    }
 }


### PR DESCRIPTION
This PR solves issues like #2534, #1631 and other.

**Usage in the content-pro-joomla particle** (as an example, use accordingly in other particles)

_YAML file_

```
article.filter.tags:
    type: input.text
    label: Tags
    description: Enter tag IDs to limit the articles that should be shown. It should be a list of tag IDs separated with a comma (i.e. 1,2,3,4,5).
    overridable: false
```

_Twig file_ (add it before the find() line(!))

```
{# Tags #}
{% set tags_options = filter.tags ? {id: [filter.tags|replace(' ', '')|split(',')]} : {} %}
{% do article_finder.tags(tags_options) %}
```

Demo video: https://downloads.kubik-rubik.de/joomla/gantry5-tags-filter.mov

