### PR TITLE
Menuitem link attributes rework, fixed #2573

### DIFF
--- a/engines/common/nucleus/particles/menu.html.twig
+++ b/engines/common/nucleus/particles/menu.html.twig
@@ -42,7 +42,13 @@
         {% set dropdown = item.level == 1 ? ' g-' ~ item.getDropdown() %}
         {% set parent = item.children ? ' g-parent' %}
         {% set target = (item.target != '_self' or context.particle.forceTarget) ? ' target="' ~ item.target|e ~ '"' %}
-        {% set rel = item.rel ? ' rel="' ~ item.rel|e ~ '"' %}
+        {% if item.target == '_blank' %}
+            {% set relTarget = ('noopener' not in item.rel) ? 'noopener' : '' %}
+            {% set relTarget = (relTarget) ? relTarget ~ ' ' : relTarget %}
+            {% set relTarget = ('noreferrer' not in item.rel) ? relTarget ~ 'noreferrer' : relTarget %}
+            {% set relTarget = (item.rel and relTarget) ? ' ' ~ relTarget : relTarget %}
+        {% endif %}
+        {% set rel = (item.rel or relTarget) ? ' rel="' ~ item.rel|e ~ relTarget ~ '"' %}
         {% set attributes = '' %}
         {% if item.attributes %}
             {% for attribute in item.attributes %}

--- a/engines/common/nucleus/particles/menu.html.twig
+++ b/engines/common/nucleus/particles/menu.html.twig
@@ -42,26 +42,48 @@
         {% set dropdown = item.level == 1 ? ' g-' ~ item.getDropdown() %}
         {% set parent = item.children ? ' g-parent' %}
         {% set target = (item.target != '_self' or context.particle.forceTarget) ? ' target="' ~ item.target|e ~ '"' %}
+
         {% if item.target == '_blank' %}
             {% set relTarget = ('noopener' not in item.rel) ? 'noopener' : '' %}
-            {% set relTarget = (relTarget) ? relTarget ~ ' ' : relTarget %}
-            {% set relTarget = ('noreferrer' not in item.rel) ? relTarget ~ 'noreferrer' : relTarget %}
+            {% if 'noreferrer' not in item.rel %}
+                {% set relTarget = (relTarget) ? relTarget ~ ' ' : relTarget %}
+                {% set relTarget = relTarget ~ 'noreferrer' %}
+            {% endif %}
             {% set relTarget = (item.rel and relTarget) ? ' ' ~ relTarget : relTarget %}
         {% endif %}
-        {% set rel = (item.rel or relTarget) ? ' rel="' ~ item.rel|e ~ relTarget ~ '"' %}
-        {% set attributes = '' %}
+
+        {% set listAttributes = '' %}
         {% if item.attributes %}
             {% for attribute in item.attributes %}
                 {% for key, value in attribute %}
-                    {% set attributes = attributes ~ ' ' ~ key|e ~ '="' ~ value|e('html_attr') ~ '"' %}
+                    {% set listAttributes = listAttributes ~ ' ' ~ key|e ~ '="' ~ value|e('html_attr') ~ '"' %}
                 {% endfor %}
             {% endfor %}
         {% endif %}
 
+        {% set linkAttributes = '' %}
+        {% set relAttribute = '' %}
+        {% if item.link_attributes %}
+            {% for attribute in item.link_attributes %}
+                {% for key, value in attribute %}
+                    {% if key == 'rel' %}
+                        {% set hValue = value|e('html_attr') %}
+                        {% if hValue not in item.rel and hValue not in relTarget %}
+                            {% set relAttribute = (item.rel or relTarget) ? ' ' : '' %}
+                            {% set relAttribute = relAttribute ~ hValue %}
+                        {% endif %}
+                    {% else %}
+                        {% set linkAttributes = linkAttributes ~ ' ' ~ key|e ~ '="' ~ value|e('html_attr') ~ '"' %}
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
+        {% endif %}
+        {% set rel = (item.rel or relTarget or relAttribute) ? ' rel="' ~ item.rel|e ~ relTarget ~ relAttribute ~ '"' %}
+
         <li class="g-menu-item g-menu-item-type-{{ item.type }} g-menu-item-{{ item.id }}{% if not item.dropdown_hide %}{{ parent }}{% endif %}{{ active }}{{ dropdown }} {% if item.url and item.children %}{% if not item.dropdown_hide %}g-menu-item-link-parent{% endif %}{% endif %} {{ item.class|default('') }}"
                 {{- self.getCustomWidth(item, menu, 'item', dropdown) }}
-                {%- if context.particle.renderTitles|default(0) %} title="{{ item.title }}"{% endif %}{{attributes|raw}}>
-            {% if item.url %}<a class="g-menu-item-container{{ item.anchor_class ? ' ' ~ item.anchor_class }}" href="{{ item.url }}{{ item.hash }}"{{ (title ~ label ~ target ~ rel)|raw }}>
+                {%- if context.particle.renderTitles|default(0) %} title="{{ item.title }}"{% endif %}{{listAttributes|raw}}>
+            {% if item.url %}<a class="g-menu-item-container{{ item.anchor_class ? ' ' ~ item.anchor_class }}" href="{{ item.url }}{{ item.hash }}"{{ (title ~ label ~ target ~ rel ~ linkAttributes)|raw }}>
             {% else %}<div class="g-menu-item-container{{ item.anchor_class ? ' ' ~ item.anchor_class }}" data-g-menuparent=""{{ label|raw }}>{% endif %}
                 {% if item.image %}
                     <img src="{{ url(item.image) }}" alt="{{ item.title }}" />

--- a/platforms/common/blueprints/menu/menuitem.yaml
+++ b/platforms/common/blueprints/menu/menuitem.yaml
@@ -51,11 +51,19 @@ form:
 
         .attributes:
           type: collection.keyvalue
-          label: Tag Attributes
-          description: Additional attributes for the menu item.
+          label: List Tag Attributes
+          description: Additional attributes for the menu item list tag.
           key_placeholder: Key (e.g. style, name, ...)
           value_placeholder: Value
-          exclude: ['id', 'class']
+          exclude: ['class', 'style', 'title']
+
+        .link_attributes:
+          type: collection.keyvalue
+          label: Link Tag Attributes
+          description: Additional attributes for the menu item link tag.
+          key_placeholder: Key (e.g. style, name, ...)
+          value_placeholder: Value
+          exclude: ['class', 'href', 'title', 'aria-label', 'target']
 
         .hash:
           type: input.text

--- a/platforms/common/blueprints/menu/menuitem.yaml
+++ b/platforms/common/blueprints/menu/menuitem.yaml
@@ -43,6 +43,11 @@ form:
         .link:
           type: input.text
           label: Link
+          
+        .rel:
+          type: input.text
+          label: Link Rel Attribute
+          disabled: true
 
         .attributes:
           type: collection.keyvalue

--- a/platforms/grav/gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/grav/gantry5/admin/blueprints/menu/menuitem.yaml
@@ -47,11 +47,19 @@ form:
 
         .attributes:
           type: collection.keyvalue
-          label: Tag Attributes
-          description: Additional attributes for the menu item.
+          label: List Tag Attributes
+          description: Additional attributes for the menu item list tag.
           key_placeholder: Key (e.g. style, name, ...)
           value_placeholder: Value
-          exclude: ['id', 'class']
+          exclude: ['class', 'style', 'title']
+
+        .link_attributes:
+          type: collection.keyvalue
+          label: Link Tag Attributes
+          description: Additional attributes for the menu item link tag.
+          key_placeholder: Key (e.g. style, name, ...)
+          value_placeholder: Value
+          exclude: ['class', 'href', 'title', 'aria-label', 'target']
 
         .hash:
           type: input.text

--- a/platforms/grav/gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/grav/gantry5/admin/blueprints/menu/menuitem.yaml
@@ -39,6 +39,11 @@ form:
           type: input.text
           label: Link
           disabled: true
+          
+        .rel:
+          type: input.text
+          label: Link Rel Attribute
+          disabled: true
 
         .attributes:
           type: collection.keyvalue

--- a/platforms/joomla/com_gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/joomla/com_gantry5/admin/blueprints/menu/menuitem.yaml
@@ -47,11 +47,19 @@ form:
 
         .attributes:
           type: collection.keyvalue
-          label: Tag Attributes
-          description: Additional attributes for the menu item.
+          label: List Tag Attributes
+          description: Additional attributes for the menu item list tag.
           key_placeholder: Key (e.g. style, name, ...)
           value_placeholder: Value
-          exclude: ['id', 'class']
+          exclude: ['class', 'style', 'title']
+
+        .link_attributes:
+          type: collection.keyvalue
+          label: Link Tag Attributes
+          description: Additional attributes for the menu item link tag.
+          key_placeholder: Key (e.g. style, name, ...)
+          value_placeholder: Value
+          exclude: ['class', 'href', 'title', 'aria-label', 'target']
 
         .hash:
           type: input.text

--- a/platforms/joomla/com_gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/joomla/com_gantry5/admin/blueprints/menu/menuitem.yaml
@@ -39,6 +39,11 @@ form:
           type: input.text
           label: Link
           disabled: true
+          
+        .rel:
+          type: input.text
+          label: Link Rel Attribute
+          disabled: true
 
         .attributes:
           type: collection.keyvalue

--- a/platforms/wordpress/gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/wordpress/gantry5/admin/blueprints/menu/menuitem.yaml
@@ -47,11 +47,19 @@ form:
 
         .attributes:
           type: collection.keyvalue
-          label: Tag Attributes
-          description: Additional attributes for the menu item.
+          label: List Tag Attributes
+          description: Additional attributes for the menu item list tag.
           key_placeholder: Key (e.g. style, name, ...)
           value_placeholder: Value
-          exclude: ['id', 'class']
+          exclude: ['class', 'style', 'title']
+
+        .link_attributes:
+          type: collection.keyvalue
+          label: Link Tag Attributes
+          description: Additional attributes for the menu item link tag.
+          key_placeholder: Key (e.g. style, name, ...)
+          value_placeholder: Value
+          exclude: ['class', 'href', 'title', 'aria-label', 'target']
 
         .hash:
           type: input.text

--- a/platforms/wordpress/gantry5/admin/blueprints/menu/menuitem.yaml
+++ b/platforms/wordpress/gantry5/admin/blueprints/menu/menuitem.yaml
@@ -39,6 +39,11 @@ form:
           type: input.text
           label: Link
           disabled: true
+          
+        .rel:
+          type: input.text
+          label: Link Rel Attribute
+          disabled: true
 
         .attributes:
           type: collection.keyvalue

--- a/src/platforms/grav/classes/Gantry/Framework/Menu.php
+++ b/src/platforms/grav/classes/Gantry/Framework/Menu.php
@@ -196,6 +196,7 @@ class Menu extends AbstractMenu
                 'parent_id' => $parent_id,
                 'layout' => 'list',
                 'target' => '_self',
+                'rel' => '',
                 'dropdown' => '',
                 'icon' => '',
                 'image' => '',

--- a/src/platforms/joomla/classes/Gantry/Framework/Menu.php
+++ b/src/platforms/joomla/classes/Gantry/Framework/Menu.php
@@ -287,6 +287,7 @@ class Menu extends AbstractMenu
                     'path' => $menuItem->route,
                     'link' => $menuItem->link,
                     'link_title' => $menuItem->params->get('menu-anchor_title', ''),
+                    'rel' => $menuItem->params->get('menu-anchor_rel', ''),
                     'enabled' => (bool) $menuItem->params->get('menu_show', 1),
                 ];
 


### PR DESCRIPTION
Hey, as brought up by @marktaylor46 (#2573) there is currently an issue with the `rel` attribute for the Gantry menu items in Joomla. The within the Joomla menu editor defined `rel` tag is not passed over to the Gantry menu. This seems to be a bug or was simply forgotten during the platform attribute implementation.

1.) Hence I fixed the **Menu.php** file for the Joomla platform and added the `rel` attribute which is now passed over to the **menu.html.twig** and **menuitem.yaml** file. I also added a dummy `rel` within the Grav platform **Menu.php** file, like it is currently handled for other attributes in that file.

2.) I added a `disabled` field in the **menuitem.yaml** file which displays the current `rel` attribute string passed over from the platform. Please see also my screenshot added on the bottom.

3.) If the link target for a menu item is `_blank` the `rel="noreferrer noopener"` tag will be automatically added. This functionality also cares if there is already a platform passed `rel` attribute and merges them correctly together without duplication. Also manually defined link attributes are considered. So if I want to extend the `rel` attribute with a custom string it is also merged into the `rel` attribute. See point 4.). 

4.) Additionally I adapted the functionality to empower users to add custom attributes on the `<a>` tag as it is already implemented for the `<li>` tag for menu items. 

5.) `<li>` as well as `<a>` attributes now contain the correct `exclude` definition so that now already existing attributes are not duplicated on this two tag types for menu items.

For further information on this PR please review the attached code. But I think this is everything that was changed.

![grafik](https://user-images.githubusercontent.com/17965908/70252724-31634c80-1782-11ea-8b53-9f20bfe3db77.png)


