### PR TITLE
Refined menu rel attribute generation, fixed #2573 double value problem

### DIFF
--- a/engines/common/nucleus/particles/menu.html.twig
+++ b/engines/common/nucleus/particles/menu.html.twig
@@ -42,14 +42,14 @@
         {% set dropdown = item.level == 1 ? ' g-' ~ item.getDropdown() %}
         {% set parent = item.children ? ' g-parent' %}
         {% set target = (item.target != '_self' or context.particle.forceTarget) ? ' target="' ~ item.target|e ~ '"' %}
+        {% set relPlatform = item.rel %}
 
         {% if item.target == '_blank' %}
-            {% set relTarget = ('noopener' not in item.rel) ? 'noopener' : '' %}
-            {% if 'noreferrer' not in item.rel %}
+            {% set relTarget = ('noopener' not in relPlatform) ? 'noopener' : '' %}
+            {% if 'noreferrer' not in relPlatform %}
                 {% set relTarget = (relTarget) ? relTarget ~ ' ' : relTarget %}
                 {% set relTarget = relTarget ~ 'noreferrer' %}
             {% endif %}
-            {% set relTarget = (item.rel and relTarget) ? ' ' ~ relTarget : relTarget %}
         {% endif %}
 
         {% set listAttributes = '' %}
@@ -68,8 +68,11 @@
                 {% for key, value in attribute %}
                     {% if key == 'rel' %}
                         {% set hValue = value|e('html_attr') %}
-                        {% if hValue not in item.rel and hValue not in relTarget %}
-                            {% set relAttribute = (item.rel or relTarget) ? ' ' : '' %}
+                        {% if hValue not in relPlatform and hValue not in relTarget %}
+                            {% if relPlatform in hValue %}
+                                {% set relPlatform = '' %}
+                            {% endif %}
+                            {% set relAttribute = relTarget ? ' ' : '' %}
                             {% set relAttribute = relAttribute ~ hValue %}
                         {% endif %}
                     {% else %}
@@ -78,7 +81,9 @@
                 {% endfor %}
             {% endfor %}
         {% endif %}
-        {% set rel = (item.rel or relTarget or relAttribute) ? ' rel="' ~ item.rel|e ~ relTarget ~ relAttribute ~ '"' %}
+
+        {% set relPlatform = ((relTarget or relAttribute) and relPlatform) ? ' ' ~ relPlatform : relPlatform %}
+        {% set rel = (relPlatform or relTarget or relAttribute) ? ' rel="' ~ relTarget ~ relAttribute ~ relPlatform|e ~ '"' %}
 
         <li class="g-menu-item g-menu-item-type-{{ item.type }} g-menu-item-{{ item.id }}{% if not item.dropdown_hide %}{{ parent }}{% endif %}{{ active }}{{ dropdown }} {% if item.url and item.children %}{% if not item.dropdown_hide %}g-menu-item-link-parent{% endif %}{% endif %} {{ item.class|default('') }}"
                 {{- self.getCustomWidth(item, menu, 'item', dropdown) }}

--- a/engines/common/nucleus/particles/menu.html.twig
+++ b/engines/common/nucleus/particles/menu.html.twig
@@ -42,39 +42,32 @@
         {% set dropdown = item.level == 1 ? ' g-' ~ item.getDropdown() %}
         {% set parent = item.children ? ' g-parent' %}
         {% set target = (item.target != '_self' or context.particle.forceTarget) ? ' target="' ~ item.target|e ~ '"' %}
-        {% set relPlatform = item.rel %}
+        {% set rel = item.rel %}
 
         {% if item.target == '_blank' %}
-            {% set relTarget = ('noopener' not in relPlatform) ? 'noopener' : '' %}
-            {% if 'noreferrer' not in relPlatform %}
-                {% set relTarget = (relTarget) ? relTarget ~ ' ' : relTarget %}
-                {% set relTarget = relTarget ~ 'noreferrer' %}
+            {% if 'noopener' not in rel %}
+                {% set rel = rel ? rel ~ ' ' : rel %}
+                {% set rel = rel ~ 'noopener' %}
+            {% endif %}
+            {% if 'noreferrer' not in rel %}
+                {% set rel = rel ? rel ~ ' ' : rel %}
+                {% set rel = rel ~ 'noreferrer' %}
             {% endif %}
         {% endif %}
 
-        {% set listAttributes = '' %}
-        {% if item.attributes %}
-            {% for attribute in item.attributes %}
-                {% for key, value in attribute %}
-                    {% set listAttributes = listAttributes ~ ' ' ~ key|e ~ '="' ~ value|e('html_attr') ~ '"' %}
-                {% endfor %}
-            {% endfor %}
-        {% endif %}
-
+        {% set listAttributes = item.attributes|attribute_array %}
         {% set linkAttributes = '' %}
-        {% set relAttribute = '' %}
+        
         {% if item.link_attributes %}
             {% for attribute in item.link_attributes %}
                 {% for key, value in attribute %}
                     {% if key == 'rel' %}
-                        {% set hValue = value|e('html_attr') %}
-                        {% if hValue not in relPlatform and hValue not in relTarget %}
-                            {% if relPlatform in hValue %}
-                                {% set relPlatform = '' %}
+                        {% for hVal in value|split(' ') %}
+                            {% if hVal not in rel %}
+                                {% set rel = rel ? rel ~ ' ' : rel %}
+                                {% set rel = rel ~ hVal %}
                             {% endif %}
-                            {% set relAttribute = relTarget ? ' ' : '' %}
-                            {% set relAttribute = relAttribute ~ hValue %}
-                        {% endif %}
+                        {% endfor %}
                     {% else %}
                         {% set linkAttributes = linkAttributes ~ ' ' ~ key|e ~ '="' ~ value|e('html_attr') ~ '"' %}
                     {% endif %}
@@ -82,9 +75,8 @@
             {% endfor %}
         {% endif %}
 
-        {% set relPlatform = ((relTarget or relAttribute) and relPlatform) ? ' ' ~ relPlatform : relPlatform %}
-        {% set rel = (relPlatform or relTarget or relAttribute) ? ' rel="' ~ relTarget ~ relAttribute ~ relPlatform|e ~ '"' %}
-
+        {% set rel = rel ? ' rel="' ~ rel|e('html_attr') ~ '"' %}
+        
         <li class="g-menu-item g-menu-item-type-{{ item.type }} g-menu-item-{{ item.id }}{% if not item.dropdown_hide %}{{ parent }}{% endif %}{{ active }}{{ dropdown }} {% if item.url and item.children %}{% if not item.dropdown_hide %}g-menu-item-link-parent{% endif %}{% endif %} {{ item.class|default('') }}"
                 {{- self.getCustomWidth(item, menu, 'item', dropdown) }}
                 {%- if context.particle.renderTitles|default(0) %} title="{{ item.title }}"{% endif %}{{listAttributes|raw}}>


### PR DESCRIPTION
As brought up by @marktaylor46 there was an issue 

<s>when `noindex, nofollow` was manually appended over a menu item and a `nofollow` was passed over from the platform (e.g. Joomla) which resulted in an attribute value like `nofollow noindex, nofollow`.</s> 

with duplication of attribute values when passed from platform (e.g. `nofollow`) and mixed with attribute values directly defined on the menu item (e.g. `nofollow noopener`). Which resulted in `nofollow nofollow noopener`. This type of problems are fixed now.

<s>This PR fixes the above explained problem. But this PR does not verify and deconstruct combined attribute values that might still exist (e.g. in WP). This is IMHO out of scope for the menu `<a>` tag generation. I'm pretty sure that it would still be possible within WP to construct a platform `rel` attribute value which results in double generation but this is something the user should take care of and not the framework. I will also now attach an example why this is problematic:

Platform String: `noopener noindex, nofollow`
Menu Attribute String: `noindex, nofollow noopener` 

This will still result in a doubled value. Please verify if we need this type of check (@mahagr  @marktaylor46). In the meantime I will think about if I can provide an easy solution (check) for this type of issue because we need to properly deconstruct the platform string and verify each element one by one...</s>

Additionally I extended the existing code so that manually added `rel` attribute values via menu item are deconstructed (splitted by blank) and one by one checked if they were already passed from the platform or automatically appended (`noreferrer noopener`). So it is now impossible to duplicate values within the `rel` attribute and every edge case should now be covered. Finally no need for the user to take care on attribute duplication, everything is hidden behind the routine. Additionally I completely reworked the code and made it simpler as well as more readable. I'm now also using the `|attribute_array` filter for attribute construction. Finally the `html_attr` is now properly applied.

#2573, #2575

Addition: I updated the description and added a strikeout on the no longer relevant parts. I original thought that the form `noindex, nofollow` is valid. This would've made the deconstruction and duplicate checks either very nasty or even impossible (multiple delimiters - mix of blank ` ` and comma `,` delimiters). A good solution for this use case would require a `preg_split` Twig extension within Gantry 5 which we currently don't have.