### PR TITLE
fixed backend field alignment (line wrap)

### DIFF
--- a/platforms/common/scss/admin/_settings.scss
+++ b/platforms/common/scss/admin/_settings.scss
@@ -153,6 +153,7 @@
 
     .settings-param-title {
         max-width: 175px;
+        width: 175px;
         margin: 5px;
 
         .particle-label-subtype {

--- a/platforms/common/scss/admin/_settings.scss
+++ b/platforms/common/scss/admin/_settings.scss
@@ -152,8 +152,7 @@
     }
 
     .settings-param-title {
-        max-width: 175px;
-        width: 175px;
+        max-width: 165px;
         margin: 5px;
 
         .particle-label-subtype {


### PR DESCRIPTION
Hey, I suggest changing this one line in the admin CSS file to get correct alignment of the fields. IDK if this affects something else but it seems that the particle modal itself and the particle defaults tab should be all.

Before:
![grafik](https://user-images.githubusercontent.com/17965908/81268096-ca570600-9047-11ea-93bc-12b3906b98a2.png)

After:
![grafik](https://user-images.githubusercontent.com/17965908/81268076-bf9c7100-9047-11ea-939e-7f9eac891339.png)

Additionally this one also fixes this ugly "mobile" line-wrap.

Before:
![grafik](https://user-images.githubusercontent.com/17965908/81268764-a8aa4e80-9048-11ea-9c90-a71b5da6c2c8.png)

After:
![grafik](https://user-images.githubusercontent.com/17965908/81268836-c081d280-9048-11ea-8ee2-2d130c2aec11.png)

This issue happens because the `margin: 5px;` is not respected within the `max-width`. Also we create a `left-margin` for `.settings-param-field` of  `175px` which occupies the space but actually we would need `185px`. You can verify this in developers tools quite easily. I reduced the `max-width` to `165px` so we consume as much space as we have (`165px` + `10px` occupied by the margin, this is 2 x 5px). 

