### PR TITLE
Added title option on To Top particle

### DIFF
--- a/engines/common/nucleus/particles/totop.html.twig
+++ b/engines/common/nucleus/particles/totop.html.twig
@@ -3,7 +3,7 @@
 {% block particle %}
 <div class="{{ particle.css.class|e }} g-particle">
     <div class="g-totop">
-        <a href="#" id="g-totop" rel="nofollow">
+        <a href="#" id="g-totop" rel="nofollow"{% if particle.title or particle.text %} title="{{particle.title ? particle.title|e : particle.text|e}}"{% endif %}>
             {% if particle.icon %}<i class="{{particle.icon}}"></i>{% endif %}
             {% if particle.content %}{{particle.content|raw}}{% endif %}
             {% if not particle.icon and not particle.content %}To Top{% endif %}

--- a/engines/common/nucleus/particles/totop.html.twig
+++ b/engines/common/nucleus/particles/totop.html.twig
@@ -1,9 +1,11 @@
 {% extends '@nucleus/partials/particle.html.twig' %}
 
+{% set linkTitle = particle.title ? particle.title|e : particle.text|e %}
+
 {% block particle %}
 <div class="{{ particle.css.class|e }} g-particle">
     <div class="g-totop">
-        <a href="#" id="g-totop" rel="nofollow"{% if particle.title or particle.text %} title="{{particle.title ? particle.title|e : particle.text|e}}"{% endif %}>
+        <a href="#" id="g-totop" rel="nofollow"{% if linkTitle %} title="{{linkTitle}}" aria-label="{{linkTitle}}"{% endif %}>
             {% if particle.icon %}<i class="{{particle.icon}}"></i>{% endif %}
             {% if particle.content %}{{particle.content|raw}}{% endif %}
             {% if not particle.icon and not particle.content %}To Top{% endif %}

--- a/engines/common/nucleus/particles/totop.yaml
+++ b/engines/common/nucleus/particles/totop.yaml
@@ -31,3 +31,9 @@ form:
       label: Text
       description: The text to be displayed for the link. HTML is allowed.
       placeholder: To Top
+
+    title:
+      type: input.text
+      label: Title
+      description: The title to be applied on the link. If no title is set here but a text is defined above, the text is used automatically for the <code>title</code>.
+      placeholder: jump to top

--- a/themes/helium/common/config/default/particles/totop.yaml
+++ b/themes/helium/common/config/default/particles/totop.yaml
@@ -3,3 +3,4 @@ css:
   class: ''
 icon: 'fa fa-chevron-up fa-fw'
 content: 'Back to top'
+title: 'Back to top'

--- a/themes/helium/common/particles/totop.html.twig
+++ b/themes/helium/common/particles/totop.html.twig
@@ -3,7 +3,7 @@
 {% block particle %}
 <div class="{{ particle.css.class|e }}">
     <div class="g-totop">
-        <a href="#" id="g-totop" rel="nofollow">
+        <a href="#" id="g-totop" rel="nofollow"{% if particle.title or particle.text %} title="{{particle.title ? particle.title|e : particle.text|e}}"{% endif %}>
             {% if particle.content %}{{particle.content|raw}}{% endif %}
             {% if particle.icon %}<i class="{{particle.icon}}"></i>{% endif %}
             {% if not particle.icon and not particle.content %}To Top{% endif %}

--- a/themes/helium/common/particles/totop.html.twig
+++ b/themes/helium/common/particles/totop.html.twig
@@ -1,9 +1,11 @@
 {% extends '@nucleus/partials/particle.html.twig' %}
 
+{% set linkTitle = particle.title ? particle.title|e : particle.text|e %}
+
 {% block particle %}
 <div class="{{ particle.css.class|e }}">
     <div class="g-totop">
-        <a href="#" id="g-totop" rel="nofollow"{% if particle.title or particle.text %} title="{{particle.title ? particle.title|e : particle.text|e}}"{% endif %}>
+        <a href="#" id="g-totop" rel="nofollow"{% if linkTitle %} title="{{linkTitle}}" aria-label="{{linkTitle}}"{% endif %}>
             {% if particle.content %}{{particle.content|raw}}{% endif %}
             {% if particle.icon %}<i class="{{particle.icon}}"></i>{% endif %}
             {% if not particle.icon and not particle.content %}To Top{% endif %}


### PR DESCRIPTION
Lighthouse suggests to add a link `title` as well as `aria-label` and this makes really sense. Hence I updated the particle and the default settings for the particle. To clarify: _When is the title / aria-label applied?_

- when there is a **Text** set for the Particle
- when there is a **Title** set for the Particle
- when both are defined the **Title** is used