### PR TITLE
[Wordpress] Load functions.php from custom folder

### DIFF
--- a/themes/helium/wordpress/functions.php
+++ b/themes/helium/wordpress/functions.php
@@ -54,3 +54,8 @@ foreach ($helpers as $file) {
 
     require $filepath;
 }
+
+// Custom Functions
+if ($customInclude = locate_template('custom/functions.php')) {
+    require $customInclude;
+}

--- a/themes/hydrogen/wordpress/functions.php
+++ b/themes/hydrogen/wordpress/functions.php
@@ -54,3 +54,8 @@ foreach ($helpers as $file) {
 
     require $filepath;
 }
+
+// Custom Functions
+if ($customInclude = locate_template('custom/functions.php')) {
+    require $customInclude;
+}


### PR DESCRIPTION
This allows for fast and persistent overrides/additions to the template functions.php
This way the template can be updated without fear of loosing your functions.php changes.

Not sure how it works with child templates tho, as I never used them  (I'm a Wordpress noob 😅), but I know the custom folder acts as a kind of override system. 
My Usecase was that we needed to change the Gutenberg width, and the only way of doing it seems to add code to your functions.php file.
