### PR TITLE
Display flex in g-page-surround

### DIFF
--- a/themes/helium/common/scss/helium/sections/_pagesurround.scss
+++ b/themes/helium/common/scss/helium/sections/_pagesurround.scss
@@ -1,6 +1,9 @@
 #g-page-surround {
 	background: $pagesurround-background;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
 
     .g-bodyonly & {
 		color: $base-text-color;


### PR DESCRIPTION
Add display (flex) and justify content (space-between) to push header to top and footer to bottom in page with a little content. Before, footer section appeared in middle position in large screens.