### PR TITLE
Update _core.scss

### DIFF
--- a/themes/hydrogen/common/scss/hydrogen/_core.scss
+++ b/themes/hydrogen/common/scss/hydrogen/_core.scss
@@ -64,7 +64,7 @@ h1, h2, h3, h4, h5, h6, strong {
 }
 
 .gantry-logo {
-	display: inline-block;
+	display: block;
 	@include breakpoint(mobile-only) {
 		display: block;
 		text-align: center;
@@ -75,5 +75,5 @@ h1, h2, h3, h4, h5, h6, strong {
 }
 
 .logo-large {
-	display: inline-block;
+	display: block;
 }


### PR DESCRIPTION
Display logo in large screens with display: block; instead inline-block.
gantry-logo and logo-large modified.