### PR TITLE
overflow-x: clip replacing overflow: hidden to fix position: sticky issue

### DIFF
--- a/engines/common/nucleus/scss/nucleus/_core.scss
+++ b/engines/common/nucleus/scss/nucleus/_core.scss
@@ -23,7 +23,7 @@ body {
 #g-page-surround {
 	min-height: 100vh;
     position: relative;
-    overflow: hidden;
+    overflow-x: clip;
 }
 
 article,

--- a/engines/common/nucleus/scss/nucleus/_offcanvas.scss
+++ b/engines/common/nucleus/scss/nucleus/_offcanvas.scss
@@ -29,7 +29,7 @@
     overflow: hidden;
 
     body, #g-page-surround {
-        overflow: hidden;
+        overflow-x: clip;
     }
 
     .g-nav-overlay {


### PR DESCRIPTION
Consistently having an issue with position: sticky without unsetting overflow: hidden and replacing with overflow-x: clip.
