### PR TITLE
Updating FontAwesome Icons in Admin area

### DIFF
--- a/platforms/common/templates/forms/fields/collection/keyvalue.html.twig
+++ b/platforms/common/templates/forms/fields/collection/keyvalue.html.twig
@@ -13,7 +13,7 @@
                     <i class="g-keyvalue-sep fa fa-fw fa-arrow-right"></i>
                     <input class="g-keyvalue-input-value" type="text" data-keyvalue-value="" value="{{ val }}" {% if field.value_placeholder is defined %}placeholder="{{ field.value_placeholder }}"{% endif %} />
                 </div>
-                <i class="fa fa-fw fa-trash font-small" aria-hidden="true" data-keyvalue-remove=""></i>
+                <i class="fas fa-fw fa-trash font-small" aria-hidden="true" data-keyvalue-remove=""></i>
             </li>
             {% endfor %}
         {% endfor %}
@@ -30,7 +30,7 @@
                 <i class="g-keyvalue-sep fa fa-fw fa-arrow-right"></i>
                 <input class="g-keyvalue-input-value" type="text" data-keyvalue-value="" value="" {% if field.value_placeholder is defined %}placeholder="{{ field.value_placeholder }}"{% endif %} />
             </div>
-            <i class="fa fa-fw fa-trash font-small" aria-hidden="true" data-keyvalue-remove=""></i>
+            <i class="fas fa-fw fa-trash font-small" aria-hidden="true" data-keyvalue-remove=""></i>
         </li>
     </ul>
     <input type="hidden" data-keyvalue-data="" data-keyvalue-exclude="{{ field.exclude|default([])|json_encode|e('html_attr') }}" name="{{ (scope ~ name ~ '._json')|fieldName }}" value="{{ value|default({})|json_encode(constant('JSON_UNESCAPED_SLASHES'))|e('html_attr') }}" />

--- a/platforms/common/templates/forms/fields/collection/list.html.twig
+++ b/platforms/common/templates/forms/fields/collection/list.html.twig
@@ -29,7 +29,7 @@
                     >
                         <span class="g-collapse" data-title="{{ labels.collapse }}" data-tip="{{ labels.collapse }}" data-tip-place="top-right"><i class="fa fa-fw fa-caret-up" aria-hidden="true"></i></span>
                         <span data-title-editable="{{ title }}" data-collection-key="{{ (scope ~ '.' ~ key ~ '.' ~ field.value)|fieldName }}" class="g-title">{{ title }}</span>
-                        <i class="fa fa-pencil fa-pencil-alt font-small" aria-hidden="true"  tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans|replace({'%s': title}) }}" data-title-edit=""></i>
+                        <i class="fas fa-pencil-alt font-small" aria-hidden="true"  tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans|replace({'%s': title}) }}" data-title-edit=""></i>
                     </h4>
                     <div class="inner-params">
                         {{ block('collection_fields') }}
@@ -70,9 +70,9 @@
                                             {% set itemValue = field.value == field.key ? key : val[field.value] %}
                                             {% if can_reorder %}<i class="fa fa-reorder font-small item-reorder" aria-hidden="true"></i>{% endif %}
                                             <a class="config-cog" href="{{ gantry.route(field_route ~ '/' ~ key) }}"><span data-title-editable="{{ itemValue }}" class="g-title">{{ itemValue }}</span></a>
-                                            {% if can_remove %}<i class="fa fa-fw fa-trash font-small" aria-hidden="true" data-collection-remove=""></i>{% endif %}
+                                            {% if can_remove %}<i class="fas fa-fw fa-trash font-small" aria-hidden="true" data-collection-remove=""></i>{% endif %}
                                             {% if can_addnew %}<i class="far fa-fw fa-copy font-small" aria-hidden="true" data-collection-duplicate=""></i>{% endif %}
-                                            <i class="fa fa-fw fa-pencil fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(itemValue) }}" data-title-edit=""></i>
+                                            <i class="fas fa-fw fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(itemValue) }}" data-title-edit=""></i>
                                         </li>
                                     {% else %}
                                         {% block collection_fields %}
@@ -112,9 +112,9 @@
                             <li data-collection-nosort="" data-collection-template="{{ field.value }}" style="display: none;">
                                 {% if can_reorder %}<i class="fa fa-reorder font-small item-reorder" aria-hidden="true"></i>{% endif %}
                                 <a class="config-cog" href="{{ gantry.route(field_route ~ '/%id%') }}"><span data-title-editable="New item" class="title">New item</span></a>
-                                {% if can_remove %}<i class="fa fa-fw fa-trash font-small" aria-hidden="true" data-collection-remove=""></i>{% endif %}
+                                {% if can_remove %}<i class="fas fa-fw fa-trash font-small" aria-hidden="true" data-collection-remove=""></i>{% endif %}
                                 {% if can_addnew %}<i class="far fa-fw fa-copy font-small" aria-hidden="true" data-collection-duplicate=""></i>{% endif %}
-                                <i class="fa fa-fw fa-pencil fa-pencil-alt font-small" aria-hidden="true" data-title-edit=""></i>
+                                <i class="fas fa-fw fa-pencil-alt font-small" aria-hidden="true" data-title-edit=""></i>
                             </li>
                         </ul>
                         {% if can_addnew %}<span class="collection-addnew button button-simple" data-collection-addnew="" title="Add new item"><i class="fa fa-plus font-small" aria-hidden="true"></i></span>{% endif %}

--- a/platforms/common/templates/menu/list.html.twig
+++ b/platforms/common/templates/menu/list.html.twig
@@ -31,4 +31,4 @@
         </li>
     {% endfor -%}
 </ul>
-<span class="submenu-reorder"><i class="fa fa-fw fa-arrows-h fa-arrows-alt-h" aria-hidden="true"></i></span>
+<span class="submenu-reorder"><i class="fas fa-fw fa-arrows-alt-h" aria-hidden="true"></i></span>

--- a/platforms/common/templates/modals/particle.html.twig
+++ b/platforms/common/templates/modals/particle.html.twig
@@ -24,7 +24,7 @@
             <div class="card settings-block">
                 <h4>
                     <span data-title-editable="{{ item.title }}" class="title">{{ item.title }}</span>
-                    <i class="fa fa-pencil fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(item.title) }}" data-title-edit=""></i>
+                    <i class="fas fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(item.title) }}" data-title-edit=""></i>
                     <span class="badge font-small">{{ item.options.type }}</span>
                     {% if particle.form.fields.enabled %}
                     {% include 'forms/fields/enable/enable.html.twig' with {'name': prefix ~ 'enabled', 'field': particle.form.fields.enabled, 'value': item.options.particle.enabled, 'default': 1} %}

--- a/platforms/common/templates/pages/configurations/layouts/create.html.twig
+++ b/platforms/common/templates/pages/configurations/layouts/create.html.twig
@@ -3,7 +3,7 @@
 {% block gantry %}
     <h2>
         <span class="title">{{ 'GANTRY5_PLATFORM_NEW_LAYOUT'|trans }}</span>
-        <i class="fa fa-pencil fa-pencil-alt font-small" aria-hidden="true" data-title-edit=""></i>
+        <i class="fas fa-pencil-alt font-small" aria-hidden="true" data-title-edit=""></i>
         <span class="float-right">
             <a href="#" class="button button-primary button-save"><i class="fa fa-check" aria-hidden="true"></i> <span>{{ 'GANTRY5_PLATFORM_SAVE'|trans }}</span></a>
             <a href="#" class="button"><i class="fa fa-sign-in" aria-hidden="true"></i> <span>{{ 'GANTRY5_PLATFORM_IMPORT'|trans }}</span></a>

--- a/platforms/common/templates/pages/configurations/layouts/particle-card.html.twig
+++ b/platforms/common/templates/pages/configurations/layouts/particle-card.html.twig
@@ -2,7 +2,7 @@
     <h4>
         {% if editable %}
             <span data-title-editable="{{ item.title|trim }}" class="title">{{ item.title|trim }}</span>
-            <i class="fa fa-pencil fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(item.title|trim) }}" data-title-edit=""></i>
+            <i class="fas fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(item.title|trim) }}" data-title-edit=""></i>
         {% else %}
             {{ title }}
         {% endif %}

--- a/platforms/common/templates/pages/configurations/settings/field.html.twig
+++ b/platforms/common/templates/pages/configurations/settings/field.html.twig
@@ -12,7 +12,7 @@
                     <span data-title-editable="{{ data.data[title]|trim }}" data-collection-key="{{ (scope ~ title)|fieldName }}" class="title">
                         {{ data.data[title] }}
                     </span>
-                    <i class="fa fa-pencil fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(data.data[title]|trim) }}" data-title-edit=""></i>
+                    <i class="fas fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(data.data[title]|trim) }}" data-title-edit=""></i>
                 {% else %}
                 {{ 'GANTRY5_PLATFORM_EDIT'|trans }}
                 {% endif %}

--- a/platforms/common/templates/pages/menu/edit.html.twig
+++ b/platforms/common/templates/pages/menu/edit.html.twig
@@ -7,7 +7,7 @@
             <span data-title-editable="{{ data.settings.title }}" class="title">
                 {{ data.settings.title }}
             </span>
-            <i class="fa fa-pencil fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(data.settings.title) }}" data-title-edit=""></i>
+            <i class="fas fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(data.settings.title) }}" data-title-edit=""></i>
             {% if blueprints.form.fields.enabled %}
             {% include 'forms/fields/enable/enable.html.twig' with {'default': true, 'name': 'enabled', 'field': blueprints.form.fields.enabled, 'value': data.enabled} %}
             {% endif %}

--- a/platforms/common/templates/pages/menu/menuitem.html.twig
+++ b/platforms/common/templates/pages/menu/menuitem.html.twig
@@ -8,7 +8,7 @@
                 {{ item.getEscapedTitles(false)|join(' <i class="fa fa-caret-right"></i> ')|raw }}
             </span>
             <span data-title-editable="{{ data.title }}" class="title">{{ data.title }}</span>
-            <i class="fa fa-pencil fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(data.title) }}" data-title-edit=""></i>
+            <i class="fas fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(data.title) }}" data-title-edit=""></i>
             {% if blueprints.fields['.enabled'] %}
             {% include 'forms/fields/enable/enable.html.twig' with {'default': true, 'name': 'enabled', 'field': blueprints.fields['.enabled'], 'value': data.enabled} %}
             {% endif %}

--- a/platforms/common/templates/pages/menu/particle.html.twig
+++ b/platforms/common/templates/pages/menu/particle.html.twig
@@ -23,7 +23,7 @@
             <div class="card settings-block">
                 <h4>
                     <span data-title-editable="{{ item.title }}" class="title">{{ item.title }}</span>
-                    <i class="fa fa-pencil fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(item.title) }}" data-title-edit=""></i>
+                    <i class="fas fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(item.title) }}" data-title-edit=""></i>
                     <span class="badge font-small">{{ item.options.type }}</span>
                     {% if particle.form.fields.enabled %}
                     {% include 'forms/fields/enable/enable.html.twig' with {'name': prefix ~ 'enabled', 'field': particle.form.fields.enabled, 'value': item.options.particle.enabled, 'default': 1} %}

--- a/platforms/common/templates/pages/positions/particle.html.twig
+++ b/platforms/common/templates/pages/positions/particle.html.twig
@@ -27,7 +27,7 @@
             <div class="card settings-block">
                 <h4>
                     <span data-title-editable="{{ item.title }}" class="title">{{ item.title }}</span>
-                    <i class="fa fa-pencil fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(item.title) }}" data-title-edit=""></i>
+                    <i class="fas fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(item.title) }}" data-title-edit=""></i>
                     <span class="badge font-small">{{ item.options.type }}</span>
                     {% if particle.form.fields.enabled %}
                     {% include 'forms/fields/enable/enable.html.twig' with {'name': prefix ~ 'enabled', 'field': particle.form.fields.enabled, 'value': item.options.particle.enabled, 'default': 1} %}

--- a/platforms/common/templates/partials/configuration-selector.html.twig
+++ b/platforms/common/templates/partials/configuration-selector.html.twig
@@ -27,7 +27,7 @@
     >
         {{ selected_title }}
     </span>
-    <i class="fa fa-pencil fa-pencil-alt font-small"
+    <i class="fas fa-pencil-alt font-small"
        aria-hidden="true"
        tabindex="0"
        aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(selected_title) }}"

--- a/platforms/wordpress/gantry5/admin/templates/modals/widget.html.twig
+++ b/platforms/wordpress/gantry5/admin/templates/modals/widget.html.twig
@@ -20,7 +20,7 @@
             <div class="card settings-block">
                 <h4>
                     <span data-title-editable="{{ item.title }}" class="title">{{ item.title }}</span>
-                    <i class="fa fa-pencil fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(item.title) }}" data-title-edit=""></i>
+                    <i class="fas fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(item.title) }}" data-title-edit=""></i>
                     <span class="badge font-small">{{ item.options.type }}</span>
                 </h4>
 

--- a/platforms/wordpress/gantry5/admin/templates/pages/configurations/content/field.html.twig
+++ b/platforms/wordpress/gantry5/admin/templates/pages/configurations/content/field.html.twig
@@ -12,7 +12,7 @@
                     <span data-title-editable="{{ data.data[title]|trim|e }}" data-collection-key="{{ (prefix ~ title)|fieldName }}" class="title">
                         {{ data.data[title] }}
                     </span>
-                    <i class="fa fa-pencil fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(data.data[title]|trim) }}" data-title-edit=""></i>
+                    <i class="fas fa-pencil-alt font-small" aria-hidden="true" tabindex="0" aria-label="{{ 'GANTRY5_PLATFORM_EDIT_TITLE'|trans(data.data[title]|trim) }}" data-title-edit=""></i>
                 {% else %}
                 Edit
                 {% endif %}


### PR DESCRIPTION
Some FontAwesome icons do not work properly when other extensions are added to Joomla. These changes are for compatability with newer versions of Joomla and FontAwesome 5.

Some important icons get broken sometimes
arrows for the spacer particle
TM (trademark) for the branding particle
For other particles that utilize the pencil, copy, trash FA icons

For the Branding particle located in:
`engines\common\nucleus\particles`
and the files
`branding.yaml`
`branding.html.twig`

In the Gantry 5 it has the class `fa fa-fw fa-trademark` on the left side menu of particles but `fas fa-fw fa-trademark` is more compatible. When the branding particle is added to a layout, it again has the class `fa fa-trademark`, and changing it to `fas fa-trademark` fixes the problem. However, I'm unable to figure out where to make these changes for this particle so it displays properly.

I am unable to pinpoint exactly what extensions trigger this issue but I do know making these changes fixes it and the changes are still compatible with a fresh install of Gantry 5. Just need to fix the Branding particle.