### PR TITLE
Fixed filepicker not explicitly defining the required upload permissions

### DIFF
--- a/src/classes/Gantry/Admin/Controller/Json/Filepicker.php
+++ b/src/classes/Gantry/Admin/Controller/Json/Filepicker.php
@@ -486,7 +486,13 @@ class Filepicker extends JsonController
             return $content !== false && $wp_filesystem && $wp_filesystem->put_contents($destination, $content, FS_CHMOD_FILE);
         }
 
-        return $this->moveLocalFile($source, $destination);
+        if (!$this->moveLocalFile($source, $destination)) {
+            return false;
+        }
+
+        $this->setLocalUploadedFilePermissions($destination);
+
+        return true;
     }
 
     /**
@@ -503,6 +509,20 @@ class Filepicker extends JsonController
             return true;
         } catch (\RuntimeException $e) {
             return false;
+        }
+    }
+
+    /**
+     * Normalize local uploads to public file permissions instead of preserving
+     * restrictive temporary upload modes.
+     *
+     * @param string $path
+     * @return void
+     */
+    protected function setLocalUploadedFilePermissions($path)
+    {
+        if (is_file($path)) {
+            @chmod($path, 0644);
         }
     }
 


### PR DESCRIPTION
### Summary

Fixes Gantry filepicker uploads preserving restrictive temporary file permissions, such as `0600`, after upload.

For local/Joomla uploads, the uploaded file is now normalised to `0644` after the move succeeds, matching Joomla Media Manager behaviour for public media files. WordPress uploads continue to use `FS_CHMOD_FILE`.