### PR TITLE
Fix 5.6.2 runtime version metadata

### DIFF
--- a/src/RealLoader.php
+++ b/src/RealLoader.php
@@ -58,8 +58,8 @@ abstract class RealLoader
             throw new \LogicException(self::$errorMessageGantryLoaded);
         }
 
-        define('GANTRY5_VERSION', '5.6.1');
-        define('GANTRY5_VERSION_DATE', '2026-05-06');
+        define('GANTRY5_VERSION', '5.6.2');
+        define('GANTRY5_VERSION_DATE', '2026-06-03');
 
         if (!defined('DS')) {
             define('DS', DIRECTORY_SEPARATOR);


### PR DESCRIPTION
## What changed

- Updated `GANTRY5_VERSION` in `src/RealLoader.php` from `5.6.1` to `5.6.2`.
- Updated `GANTRY5_VERSION_DATE` from `2026-05-06` to the 5.6.2 changelog date, `2026-06-03`.

## Why

The 5.6.2 release updated the root `VERSION` file and changelog, but the runtime constants in `RealLoader.php` remained on the prior release. Gantry themes read `GANTRY5_VERSION` when checking framework compatibility, so an installed 5.6.2 package could still be reported as 5.6.1 and prompt for an unnecessary framework update.

## Impact

Gantry now reports the installed framework version consistently as 5.6.2, preventing themes from treating the current framework release as outdated.

## Validation

- `php -l src/RealLoader.php`
- `php tests/php83/phpunit.phar --configuration phpunit.xml.dist` (14 tests, 24 assertions, 2 skipped)
- Confirmed `GANTRY5_VERSION` matches the root `VERSION` file and the runtime date matches the 5.6.2 changelog date.
